### PR TITLE
Simplify a proof & other minor stuff

### DIFF
--- a/Continuity.v
+++ b/Continuity.v
@@ -115,21 +115,7 @@ intros.
 destruct H1.
 destruct H1 as [A [? [V' []]]].
 rewrite H3.
-assert (inverse_image f (IndexedIntersection V') =
-  IndexedIntersection (fun a:A => inverse_image f (V' a))).
-apply Extensionality_Ensembles; split; red; intros.
-destruct H4.
-inversion_clear H4.
-constructor; intros.
-constructor.
-apply H5.
-destruct H4.
-constructor.
-constructor; intros.
-destruct (H4 a).
-exact H5.
-
-rewrite H4.
+rewrite inverse_image_indexed_intersection.
 apply open_finite_indexed_intersection; trivial.
 intros.
 apply H0.

--- a/FiniteIntersectionLemmas.v
+++ b/FiniteIntersectionLemmas.v
@@ -206,7 +206,7 @@ apply countable_union.
                 (finite_intersections_len_0_full_set HV).
   + destruct (finite_intersections_len_S_choice F n) as [g Hg],
              IHn as [fn Hfn].
-    refine (inj_countable (fun U => 
+    refine (inj_countable (fun U =>
       (fn (fst (g U)),
        f (exist _ (proj1_sig (snd (g U))) _)))
       countable_nat_product _).

--- a/InverseImageLemmas.v
+++ b/InverseImageLemmas.v
@@ -98,7 +98,7 @@ Proof.
     econstructor.
     + constructor.
       erewrite inverse_image_id.
-      * exact H0.  
+      * exact H0.
       * exact Hfg.
     + rewrite Hgf.
       constructor.
@@ -168,7 +168,7 @@ Proof.
     intros;
     inversion H;
     subst;
-    (left; 
+    (left;
      assumption) +
     (right;
      inversion H0;

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ topological spaces
 - `WeakTopology.v` - weak topology induced by a family of maps to
 topological spaces
 - `ProductTopology.v`
+- `SumTopology.v` - also called "disjoint union" or "coproduct"
 - `SubspaceTopology.v`
+- `QuotientTopology.v`
 - `ContinuousFactorization.v` - a continuous map factors through its image
 
 ### Metric spaces

--- a/coq-topology.opam
+++ b/coq-topology.opam
@@ -17,7 +17,7 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.11" & < "8.14~") | (= "dev")}
-  "coq-zorns-lemma" {(>= "8.11" & < "8.14~") | (= "dev")}
+  "coq-zorns-lemma" {= "dev"}
 ]
 
 tags: [


### PR DESCRIPTION
As the commits say, I simplified a proof in Continuity.v using a corresponding lemma from zorns-lemma, removed some trailing whitespace and mentioned some of the new files in the readme.