### PR TITLE
Metadata fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Topology Coq contribution, Copyright (C) 2011 Daniel Schepler
+Topology and Zorn's Lemma, Copyright (C) 2011-present Daniel Schepler
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/README.md
+++ b/README.md
@@ -52,15 +52,12 @@ opam repo add coq-released https://coq.inria.fr/opam/released
 opam install coq-topology
 ```
 
-To instead build and install manually, do:
-
+To instead build both Topology and Zorn's Lemma manually, do:
 ``` shell
 git clone https://github.com/coq-community/topology.git
 cd topology
-make   # or make -j <number-of-cores-on-your-machine> 
-make install
+make   # or make -j <number-of-cores-on-your-machine>
 ```
-
 
 ## Contents of Topology, roughly grouped in related categories:
 
@@ -122,7 +119,7 @@ topological spaces
 - `UrysohnsLemma.v`
 - `TietzeExtension.v`
 
-## Contents of ZornsLemma
+## Contents of Zorn's Lemma
 
 In alphabetical order, except where related files are grouped together:
 

--- a/meta.yml
+++ b/meta.yml
@@ -62,6 +62,24 @@ keywords:
 categories:
 - name: Mathematics/Real Calculus and Topology
 
+build: |-
+  ## Building and installation instructions
+
+  The easiest way to install the latest released version of Topology
+  is via [OPAM](https://opam.ocaml.org/doc/Install.html):
+
+  ```shell
+  opam repo add coq-released https://coq.inria.fr/opam/released
+  opam install coq-topology
+  ```
+
+  To instead build both Topology and Zorn's Lemma manually, do:
+  ``` shell
+  git clone https://github.com/coq-community/topology.git
+  cd topology
+  make   # or make -j <number-of-cores-on-your-machine>
+  ```
+
 documentation: |-
   ## Contents of Topology, roughly grouped in related categories:
 
@@ -123,7 +141,7 @@ documentation: |-
   - `UrysohnsLemma.v`
   - `TietzeExtension.v`
 
-  ## Contents of ZornsLemma
+  ## Contents of Zorn's Lemma
 
   In alphabetical order, except where related files are grouped together:
 


### PR DESCRIPTION
Unfortunately, `make install` (i.e., installation without Dune) will not work unless we add a bunch more boilerplate. Make this explicit in the README.