### PR TITLE
Miscellaneous changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.vos
 .Makefile.coq.d
 .coqdeps.d
+.coq-native
 Makefile.conf
 Makefile.coq
 Makefile.coq.conf

--- a/theories/Topology/Compactness.v
+++ b/theories/Topology/Compactness.v
@@ -386,7 +386,7 @@ assert (In S x0).
 exists (exist _ x0 H3).
 red; intros.
 red; intros.
-rewrite subspace_topology_topology in H4.
+rewrite subspace_open_char in H4.
 destruct H4 as [V []].
 rewrite H6 in H5.
 destruct H5.

--- a/theories/Topology/Compactness.v
+++ b/theories/Topology/Compactness.v
@@ -386,13 +386,14 @@ assert (In S x0).
 exists (exist _ x0 H3).
 red; intros.
 red; intros.
-destruct (subspace_topology_topology _ _ _ H4) as [V []].
-rewrite H7 in H5.
+rewrite subspace_topology_topology in H4.
+destruct H4 as [V []].
+rewrite H6 in H5.
 destruct H5.
 simpl in H5.
-destruct (H2 V H6 H5 i) as [j []]; trivial.
+destruct (H2 V H4 H5 i) as [j []]; trivial.
 exists j; split; trivial.
-rewrite H7.
+rewrite H6.
 now constructor.
 Qed.
 

--- a/theories/Topology/Completion.v
+++ b/theories/Topology/Completion.v
@@ -1,6 +1,6 @@
-Require Export Completeness.
-Require Import UniformTopology RTopology Psatz.
-From Coq Require Import ProofIrrelevance.
+From Coq Require Import Description ProofIrrelevance Psatz.
+From Topology Require Export Completeness.
+From Topology Require Import UniformTopology RTopology.
 
 Lemma completion_exists: forall (X:Type) (d:X->X->R) (d_metric:metric d),
   exists Y:Type, exists i:X->Y, exists d':Y->Y->R,
@@ -22,19 +22,21 @@ cut (exists Y:Type, exists i:X->Y, exists d':Y->Y->R,
   pose (F := closure (Im Full_set i) (X:=MetricTopology d' d'_metric)).
   exists {y:Y | In F y}.
   assert (forall x:X, In F (i x)).
-{ intros.
-  apply closure_inflationary.
-  exists x; trivial.
-  constructor. }
+  { intros.
+    apply closure_inflationary.
+    exists x; trivial.
+    constructor.
+  }
   exists (fun x:X => exist _ (i x) (H2 x)).
   exists (fun y1 y2 => d' (proj1_sig y1) (proj1_sig y2)).
   assert (d'_metric0 : metric (fun (y1 y2:{y:Y | In F y}) =>
                          d' (proj1_sig y1) (proj1_sig y2))).
-{ constructor; try destruct x; try destruct y; try destruct z; simpl;
-    try apply d'_metric.
-  intros.
-  apply ProofIrrelevance.ProofIrrelevanceTheory.subset_eq_compat.
-  now apply d'_metric. }
+  { constructor; try destruct x; try destruct y; try destruct z; simpl;
+      try apply d'_metric.
+    intros.
+    apply ProofIrrelevance.ProofIrrelevanceTheory.subset_eq_compat.
+    now apply d'_metric.
+  }
   exists d'_metric0.
   repeat split.
   + red; intros.
@@ -42,7 +44,7 @@ cut (exists Y:Type, exists i:X->Y, exists d':Y->Y->R,
     apply H; trivial.
   + red.
     apply Extensionality_Ensembles; split; red; intros.
-  { constructor. }
+    { constructor. }
     simpl in x.
     destruct x.
     clear H3.
@@ -50,30 +52,30 @@ cut (exists Y:Type, exists i:X->Y, exists d':Y->Y->R,
     apply first_countable_sequence_closure in i0.
     * destruct i0, H3.
       assert (forall n:nat, { x:X | x0 n = i x }).
-    { intros.
-      Require Import Description.
-      apply constructive_definite_description.
-      apply -> unique_existence.
-      split.
-      - destruct (H3 n).
-        now exists x1.
-      - red; intros.
-        apply H.
-        now rewrite H5 in H6. }
+      { intros.
+        apply constructive_definite_description.
+        apply -> unique_existence.
+        split.
+        - destruct (H3 n).
+          now exists x1.
+        - red; intros.
+          apply H.
+          now rewrite H5 in H6.
+      }
       assert (forall n:nat, In F (i (proj1_sig (X0 n)))).
-    { intros. apply H2. }
+      { intros. apply H2. }
       intros.
       apply (@net_limit_in_closure nat_DS
         (MetricTopology _ d'_metric0)
         _ (fun n:nat => exist _ (i (proj1_sig (X0 n))) (H5 n))).
-      ** red; intros.
+      -- red; intros.
          exists i1.
          split.
-         *** simpl; auto with arith.
-         *** exists (proj1_sig (X0 i1)).
-             **** constructor.
-             **** now apply subset_eq_compat.
-      ** pose proof (metric_space_net_limit_converse (MetricTopology d' d'_metric) d'
+         ++ simpl; auto with arith.
+         ++ exists (proj1_sig (X0 i1)).
+            ** constructor.
+            ** now apply subset_eq_compat.
+      -- pose proof (metric_space_net_limit_converse (MetricTopology d' d'_metric) d'
            (MetricTopology_metrizable _ d' d'_metric) nat_DS x0 x H4).
          apply metric_space_net_limit with (1:=MetricTopology_metrizable _ _ d'_metric0).
          (*
@@ -141,7 +143,7 @@ cut (exists Y:Type, exists i:X->Y, exists d':Y->Y->R,
              destruct H1.
              rewrite H2; apply H.
          *** exists x1.
-             constructor.
+             { constructor. }
              rewrite metric_zero; trivial.
              unfold R_metric.
              rewrite (metric_sym _ _ d_metric x2 x1).

--- a/theories/Topology/ContinuousFactorization.v
+++ b/theories/Topology/ContinuousFactorization.v
@@ -18,7 +18,7 @@ Lemma factorization_is_continuous:
 Proof.
 red.
 intros.
-rewrite subspace_topology_topology in H.
+rewrite subspace_open_char in H.
 destruct H as [V' []].
 subst V.
 rewrite <- inverse_image_composition.

--- a/theories/Topology/ContinuousFactorization.v
+++ b/theories/Topology/ContinuousFactorization.v
@@ -18,14 +18,15 @@ Lemma factorization_is_continuous:
 Proof.
 red.
 intros.
-destruct (subspace_topology_topology _ _ V H) as [V' []].
-rewrite H1, <- inverse_image_composition.
+rewrite subspace_topology_topology in H.
+destruct H as [V' []].
+subst V.
+rewrite <- inverse_image_composition.
 simpl.
-assert (inverse_image (fun x:point_set X => f x) V' =
-        inverse_image f V').
-{ extensionality_ensembles; now constructor. }
-rewrite H2.
-now apply f_cont.
+replace (inverse_image (fun x:point_set X => f x) V')
+        with (inverse_image f V').
+- now apply f_cont.
+- extensionality_ensembles; now constructor.
 Qed.
 
 End continuous_factorization.

--- a/theories/Topology/MetricSpaces.v
+++ b/theories/Topology/MetricSpaces.v
@@ -99,6 +99,20 @@ intros.
 apply Build_TopologicalSpace_from_open_neighborhood_bases_basis.
 Qed.
 
+Lemma metric_space_open_ball_open :
+  forall (X:TopologicalSpace) (d:point_set X -> point_set X -> R),
+    metrizes X d -> metric d ->
+    forall x r, r > 0 -> open (open_ball _ d x r).
+Proof.
+  intros.
+  specialize (H x).
+  assert (In (metric_topology_neighborhood_basis d x) (open_ball _ d x r)).
+  { constructor. assumption. }
+  apply H in H2.
+  destruct H2.
+  assumption.
+Qed.
+
 Require Export Nets.
 
 Lemma metric_space_net_limit: forall (X:TopologicalSpace)
@@ -447,6 +461,46 @@ as [choice_fun].
       now red.
     * intro.
       now destruct (H2 a) as [? [? ?]].
+Qed.
+
+Lemma metrizable_Hausdorff :
+  forall X, metrizable X -> Hausdorff X.
+Proof.
+  intros. red; intros.
+  destruct H.
+  exists (open_ball _ d x ((d x y)/2)).
+  exists (open_ball _ d y ((d x y)/2)).
+  assert (0 < d x y).
+  { apply NNPP. intro.
+    contradict H0.
+    apply not_Rlt in H2.
+    apply metric_strict with (d := d).
+    { assumption. }
+    apply Rle_antisym.
+    + apply Rge_le. assumption.
+    + apply Rge_le. apply metric_nonneg. assumption.
+  }
+  assert (d x y / 2 > 0). {
+    apply Rdiv_lt_0_compat; try assumption.
+    apply Rlt_0_2.
+  }
+  repeat split.
+  - apply metric_space_open_ball_open; assumption.
+  - apply metric_space_open_ball_open; assumption.
+  - rewrite metric_zero; assumption.
+  - rewrite metric_zero; assumption.
+  - apply Extensionality_Ensembles; split; red; intros.
+    2: { destruct H4. }
+    destruct H4. destruct H4, H5.
+    assert (d x x0 + d x0 y < d x y).
+    { rewrite double_var.
+      apply Rplus_lt_compat; try assumption.
+      rewrite metric_sym; assumption.
+    }
+    pose proof (triangle_inequality _ _ H x x0 y).
+    pose proof (Rle_lt_trans _ _ _ H7 H6).
+    apply Rlt_irrefl in H8.
+    contradiction.
 Qed.
 
 Section dist_to_set.

--- a/theories/Topology/QuotientTopology.v
+++ b/theories/Topology/QuotientTopology.v
@@ -54,7 +54,7 @@ Lemma quotient_compact {X : TopologicalSpace} (R : Relation (point_set X)) :
 Proof.
 intros H F HF eqF.
 apply (f_equal (inverse_image (quotient_projection R))) in eqF.
-rewrite inverse_image_full_set,
+rewrite inverse_image_full,
         inverse_image_family_union_image in eqF.
 apply H in eqF.
 - destruct eqF as [F' [H1 [H2 H3]]].

--- a/theories/Topology/RFuncContinuity.v
+++ b/theories/Topology/RFuncContinuity.v
@@ -10,21 +10,22 @@ Proof.
 split.
 - intros H eps H0.
   assert (neighbourhood (inverse_image f [r : R | Rabs (r - f x) < eps]) x) as H1.
-  apply RTop_neighborhood_is_neighbourhood, H, open_neighborhood_is_neighborhood.
-  split.
-  + replace [r : R | Rabs (r - f x) < eps] with [r : R | f x - eps < r < f x + eps]
-      by (extensionality_ensembles;
-          constructor;
-          apply Rabs_def1 + apply Rabs_def2 in H1;
-          lra).
-    apply R_interval_open.
-  + constructor.
-    apply Rabs_def1; lra.
-  + destruct H1 as [[alp H1] H2].
-    exists alp.
-    split; trivial.
-    intros x0 [? H3].
-    now destruct (H2 _ H3) as [[?]].
+  { apply RTop_neighborhood_is_neighbourhood, H, open_neighborhood_is_neighborhood.
+    split.
+    - replace [r : R | Rabs (r - f x) < eps] with [r : R | f x - eps < r < f x + eps]
+        by (extensionality_ensembles;
+            constructor;
+            apply Rabs_def1 + apply Rabs_def2 in H1;
+            lra).
+      apply R_interval_open.
+    - constructor.
+      apply Rabs_def1; lra.
+  }
+  destruct H1 as [[alp H1] H2].
+  exists alp.
+  split; trivial.
+  intros x0 [? H3].
+  now destruct (H2 _ H3) as [[?]].
 - intros H U HU.
   apply RTop_neighborhood_is_neighbourhood.
   pose HU as H0.
@@ -340,8 +341,8 @@ exists (fun x => (subspace_inc U x) / (1 - Rabs (subspace_inc U x))).
   + apply diff_continuous.
     * apply continuous_func_continuous_everywhere, continuous_constant.
     * apply continuous_composition_at.
-      apply continuous_func_continuous_everywhere, Rabs_continuous.
-      apply continuous_func_continuous_everywhere, subspace_inc_continuous.
+      -- apply continuous_func_continuous_everywhere, Rabs_continuous.
+      -- apply continuous_func_continuous_everywhere, subspace_inc_continuous.
   + destruct x as [x [[]]]. simpl.
     cut (Rabs x < 1).
     * lra.

--- a/theories/Topology/RTopology.v
+++ b/theories/Topology/RTopology.v
@@ -203,80 +203,82 @@ destruct (classic (inhabited (DS_set I))) as [Hinh|Hempty].
       constructor.
       apply preord_refl, DS_ord_cond. }
   assert ({ x0:R | is_lub (Im Full_set (fun i => proj1_sig (X i))) x0 }).
-  apply sup.
-  + exists b.
-    red. intros.
-    destruct H0 as [i].
-    destruct (X i).
-    simpl in H1.
-    rewrite H1.
-    destruct i0.
-    cut (b >= x0); auto with real.
-    apply Rge_trans with (x i).
-    * destruct (H i). lra.
-    * apply H2.
-      exists i; trivial.
-      constructor.
-      apply preord_refl, DS_ord_cond.
-  + destruct Hinh as [i0].
-    exists (proj1_sig (X i0)).
-    exists i0; trivial.
-    constructor.
-  + destruct H0 as [x0].
-    exists x0.
-    assert (forall i j:DS_set I, DS_ord i j ->
-      proj1_sig (X i) <= proj1_sig (X j)).
-    * intros.
-      destruct (X i0), (X j).
-      simpl.
-      destruct i1, i2.
-      apply H4.
+  { apply sup.
+    - exists b.
       red. intros.
-      destruct H5.
-      destruct H5.
-      apply H1.
-      exists x3; trivial.
+      destruct H0 as [i].
+      destruct (X i).
+      simpl in H1.
+      rewrite H1.
+      destruct i0.
+      cut (b >= x0); auto with real.
+      apply Rge_trans with (x i).
+      + destruct (H i). lra.
+      + apply H2.
+        exists i; trivial.
+        constructor.
+        apply preord_refl, DS_ord_cond.
+    - destruct Hinh as [i0].
+      exists (proj1_sig (X i0)).
+      exists i0; trivial.
       constructor.
-      apply preord_trans with j; trivial.
-      apply DS_ord_cond.
-  * red. intros.
-    destruct (RTop_metrization x0).
-    destruct (open_neighborhood_basis_cond U).
-    { now split. }
-    destruct H3.
-    destruct H3.
-    destruct (lub_approx _ _ r i); trivial.
+  }
+  destruct H0 as [x0].
+  exists x0.
+  assert (forall i j:DS_set I,
+             DS_ord i j -> proj1_sig (X i) <= proj1_sig (X j)).
+  { intros.
+    destruct (X i0), (X j).
+    simpl.
+    destruct i1, i2.
+    apply H4.
+    red. intros.
     destruct H5.
     destruct H5.
-    destruct H6.
-    red; intros.
-    destruct (DS_join_cond x1 i0).
-    destruct H9.
-    remember (X x2) as y2.
-    destruct y2.
-    destruct (glb_approx _ _ r i1); trivial.
-    destruct H11.
-    destruct H11.
-    destruct H11.
-    destruct H12.
-    exists x4.
-    split.
-    ** apply preord_trans with x2; trivial.
-       apply DS_ord_cond.
-    ** apply H4.
-       constructor.
-       assert (y <= proj1_sig (X x2)).
-       { rewrite H7.
-         now apply H0. }
-       rewrite <- Heqy2 in H15.
-       simpl in H15.
-       assert (proj1_sig (X x2) <= x0).
-       { apply i.
-         exists x2; trivial.
-         constructor. }
-       rewrite <- Heqy2 in H16.
-       simpl in H16.
-       apply Rabs_def1; lra.
+    apply H1.
+    exists x3; trivial.
+    constructor.
+    apply preord_trans with j; trivial.
+    apply DS_ord_cond.
+  }
+  red. intros.
+  destruct (RTop_metrization x0).
+  destruct (open_neighborhood_basis_cond U).
+  { now split. }
+  destruct H3.
+  destruct H3.
+  destruct (lub_approx _ _ r i); trivial.
+  destruct H5.
+  destruct H5.
+  destruct H6.
+  red; intros.
+  destruct (DS_join_cond x1 i0).
+  destruct H9.
+  remember (X x2) as y2.
+  destruct y2.
+  destruct (glb_approx _ _ r i1); trivial.
+  destruct H11.
+  destruct H11.
+  destruct H11.
+  destruct H12.
+  exists x4.
+  split.
+  + apply preord_trans with x2; trivial.
+    apply DS_ord_cond.
+  + apply H4.
+    constructor.
+    assert (y <= proj1_sig (X x2)).
+    { rewrite H7.
+      now apply H0. }
+    rewrite <- Heqy2 in H15.
+    simpl in H15.
+    assert (proj1_sig (X x2) <= x0).
+    { apply i.
+      exists x2; trivial.
+      constructor. }
+    rewrite <- Heqy2 in H16.
+    simpl in H16.
+    apply Rabs_def1; lra.
 - exists a.
   red. intros.
   red. intros.
@@ -640,8 +642,8 @@ apply intro_ctbl_basis with
     * apply open_full.
     * destruct H as [S [[q Hq] H]| S [[q Hq] H]];
         subst.
-      apply R_lower_beam_open.
-      apply R_upper_beam_open.
+      -- apply R_lower_beam_open.
+      -- apply R_upper_beam_open.
     * now apply (@open_intersection2 RTop).
   + intros r U H1 H2.
     assert (neighborhood U r) as H by now exists U.

--- a/theories/Topology/RTopology.v
+++ b/theories/Topology/RTopology.v
@@ -328,7 +328,7 @@ destruct (bounded_real_net_has_cluster_point _ y a b).
     now destruct i. }
   exists (exist _ x0 H2).
   red. intros.
-  rewrite subspace_topology_topology in H3.
+  rewrite subspace_open_char in H3.
   destruct H3 as [V []].
   subst U.
   destruct H4.

--- a/theories/Topology/RTopology.v
+++ b/theories/Topology/RTopology.v
@@ -328,16 +328,16 @@ destruct (bounded_real_net_has_cluster_point _ y a b).
     now destruct i. }
   exists (exist _ x0 H2).
   red. intros.
-  destruct (subspace_topology_topology _ _ _ H3) as [V].
-  destruct H5.
+  rewrite subspace_topology_topology in H3.
+  destruct H3 as [V []].
+  subst U.
+  destruct H4.
   red. intros.
   assert (Ensembles.In V x0).
-  { rewrite H6 in H4.
-    now destruct H4. }
-  destruct (H0 V H5 H7 i) as [j []].
+  { assumption. }
+  destruct (H0 V H3 H4 i) as [j []].
   exists j.
   split; trivial.
-  rewrite H6.
   now constructor.
 Qed.
 

--- a/theories/Topology/SubspaceTopology.v
+++ b/theories/Topology/SubspaceTopology.v
@@ -30,3 +30,35 @@ End Subspace.
 
 Arguments SubspaceTopology {X}.
 Arguments subspace_inc {X}.
+
+(* If the subspace [F] is closed in [X], then its [subspace_inc] is a
+   closed map. *)
+Lemma subspace_inc_takes_closed_to_closed
+  (X : TopologicalSpace) (F:Ensemble (point_set X)) :
+  closed F ->
+  forall G:Ensemble (point_set (SubspaceTopology F)),
+  closed G -> closed (Im G (subspace_inc F)).
+Proof.
+intros.
+red in H0.
+apply subspace_topology_topology in H0.
+destruct H0 as [U []].
+replace (Im G (subspace_inc F)) with
+  (Intersection F (Complement U)).
+{ apply closed_intersection2; trivial.
+  red. now rewrite Complement_Complement. }
+apply Extensionality_Ensembles; split; red; intros.
+- destruct H2.
+  exists (exist _ x H2); trivial.
+  apply NNPP. intro.
+  change (In (Complement G) (exist (In F) x H2)) in H4.
+  rewrite H1 in H4.
+  now destruct H4.
+- destruct H2 as [[y]].
+  subst y0.
+  constructor; trivial.
+  intro.
+  absurd (In (Complement G) (exist _ y i)).
+  + now intro.
+  + now rewrite H1.
+Qed.

--- a/theories/Topology/SubspaceTopology.v
+++ b/theories/Topology/SubspaceTopology.v
@@ -19,7 +19,7 @@ Proof.
 apply weak_topology1_makes_continuous_func.
 Qed.
 
-Lemma subspace_topology_topology: forall U:Ensemble {x:point_set X | In A x},
+Lemma subspace_open_char: forall U:Ensemble {x:point_set X | In A x},
   @open SubspaceTopology U <-> exists V:Ensemble (point_set X),
   open V /\ U = inverse_image subspace_inc V.
 Proof.
@@ -44,7 +44,7 @@ Lemma subspace_inc_takes_closed_to_closed
 Proof.
 intros.
 red in H0.
-rewrite subspace_topology_topology in H0.
+rewrite subspace_open_char in H0.
 destruct H0 as [U []].
 replace (Im G (subspace_inc F)) with
   (Intersection F (Complement U)).

--- a/theories/Topology/SubspaceTopology.v
+++ b/theories/Topology/SubspaceTopology.v
@@ -13,17 +13,20 @@ Definition subspace_inc : point_set SubspaceTopology ->
   point_set X :=
   proj1_sig (P:=fun x:point_set X => In A x).
 
-Lemma subspace_topology_topology: forall U:Ensemble {x:point_set X | In A x},
-  @open SubspaceTopology U -> exists V:Ensemble (point_set X),
-  open V /\ U = inverse_image subspace_inc V.
-Proof.
-apply weak_topology1_topology.
-Qed.
-
 Lemma subspace_inc_continuous:
   continuous subspace_inc.
 Proof.
 apply weak_topology1_makes_continuous_func.
+Qed.
+
+Lemma subspace_topology_topology: forall U:Ensemble {x:point_set X | In A x},
+  @open SubspaceTopology U <-> exists V:Ensemble (point_set X),
+  open V /\ U = inverse_image subspace_inc V.
+Proof.
+split.
+- apply weak_topology1_topology.
+- intros. destruct H as [V []].
+  subst. apply subspace_inc_continuous. assumption.
 Qed.
 
 End Subspace.
@@ -41,7 +44,7 @@ Lemma subspace_inc_takes_closed_to_closed
 Proof.
 intros.
 red in H0.
-apply subspace_topology_topology in H0.
+rewrite subspace_topology_topology in H0.
 destruct H0 as [U []].
 replace (Im G (subspace_inc F)) with
   (Intersection F (Complement U)).

--- a/theories/Topology/TietzeExtension.v
+++ b/theories/Topology/TietzeExtension.v
@@ -537,7 +537,7 @@ apply Rplus_lt_compat.
   unfold uniform_metric; simpl; destruct sup; simpl.
   apply i.
   exists (subspace_inc F x).
-  constructor.
+  { constructor. }
   apply R_metric_is_metric.
 - assert ((N >= N2)%nat) by apply le_max_r.
   apply Rle_lt_trans with (2:=H3 N H4).
@@ -615,7 +615,7 @@ Lemma bounded_Tietze_extension_theorem: forall (X:TopologicalSpace)
 Proof.
 intros.
 destruct (classic (inhabited (point_set X))) as [Hinh|Hempty].
-- destruct (choice (fun 
+- destruct (choice (fun
     (FG:{FG:Ensemble (point_set X) * Ensemble (point_set X) | let (F,G):=FG in
                       closed F /\ closed G /\ Intersection F G = Empty_set})
     (phi:point_set X -> point_set RTop) =>

--- a/theories/Topology/TietzeExtension.v
+++ b/theories/Topology/TietzeExtension.v
@@ -26,32 +26,6 @@ Variable Urysohns_lemma_function:
   (forall x:point_set X, In F x -> f x = 0) /\
   (forall x:point_set X, In G x -> f x = 1) }.
 
-Lemma subspace_inc_takes_closed_to_closed:
-  forall G:Ensemble (point_set (SubspaceTopology F)),
-  closed G -> closed (Im G (subspace_inc F)).
-Proof.
-intros.
-destruct (subspace_topology_topology _ _ _ H) as [U []].
-replace (Im G (subspace_inc F)) with
-  (Intersection F (Complement U)).
-{ apply closed_intersection2; trivial.
-  red. now rewrite Complement_Complement. }
-apply Extensionality_Ensembles; split; red; intros.
-- destruct H2.
-  exists (exist _ x H2); trivial.
-  apply NNPP. intro.
-  change (In (Complement G) (exist (In F) x H2)) in H4.
-  rewrite H1 in H4.
-  now destruct H4.
-- destruct H2 as [[y]].
-  rewrite H3. clear y0 H3.
-  constructor; trivial.
-  intro.
-  absurd (In (Complement G) (exist _ y i)).
-  + now intro.
-  + now rewrite H1.
-Qed.
-
 Lemma Rle_order: order Rle.
 Proof.
 constructor;
@@ -77,7 +51,7 @@ refine (
              (subspace_inc F) in
   let g:=proj1_sig (Urysohns_lemma_function F0 G0 _ _ _) in
   fun x:point_set X => -1/3 + 2/3 * g x).
-- apply subspace_inc_takes_closed_to_closed.
+- apply subspace_inc_takes_closed_to_closed; [assumption|].
   replace ([ x:point_set (SubspaceTopology F) | f0 x <= -1/3 ]) with
     (inverse_image f0 [ y:point_set RTop | y <= -1/3 ]).
   + red.
@@ -92,7 +66,7 @@ refine (
     * now constructor.
     * constructor.
       now constructor.
-- apply subspace_inc_takes_closed_to_closed.
+- apply subspace_inc_takes_closed_to_closed; [assumption|].
   replace ([ x:point_set (SubspaceTopology F) | f0 x >= 1/3 ]) with
     (inverse_image f0 [ y:point_set RTop | 1/3 <= y ]).
   + red.

--- a/theories/Topology/UrysohnsLemma.v
+++ b/theories/Topology/UrysohnsLemma.v
@@ -325,7 +325,7 @@ change ((m + (m + 0))%nat) with ((2*m)%nat).
 rewrite div2_double.
 assert (forall m:nat, even (2*m)).
 { induction m0.
-  constructor.
+  { constructor. }
   replace ((2 * S m0)%nat) with ((S (S (2 * m0)))%nat) by ring.
   constructor.
   now constructor. }
@@ -540,7 +540,7 @@ destruct H.
       ** destruct H1.
          assert (Urysohns_Lemma_function x0 < x).
          { destruct H1.
-           destruct (Rdichotomy _ _ H2); trivial.
+           { destruct (Rdichotomy _ _ H2); trivial. }
            contradict H2.
            auto with real. }
          clear H1.
@@ -655,9 +655,9 @@ destruct H.
          pose proof (U_dyadic_incr _ _ H8).
          assert (x < Q2R (dr2Q beta) < 1).
          { split.
-           apply H7.
+           { apply H7. }
            apply Rlt_trans with (Q2R (dr2Q alpha)).
-           apply H7.
+           { apply H7. }
            apply Rlt_le_trans with y; trivial.
            apply H5. }
          exists (exist (fun alpha0:dyadic_rational =>

--- a/theories/ZornsLemma/InverseImage.v
+++ b/theories/ZornsLemma/InverseImage.v
@@ -190,22 +190,6 @@ Proof.
     assumption.
 Qed.
 
-Lemma inverse_image_empty_set {X Y : Type} (f : X -> Y) :
-  inverse_image f Empty_set = Empty_set.
-Proof.
-apply Extensionality_Ensembles.
-split; red; intros;
-  repeat destruct H.
-Qed.
-
-Lemma inverse_image_full_set {X Y : Type} (f : X -> Y) :
-  inverse_image f Full_set = Full_set.
-Proof.
-apply Extensionality_Ensembles.
-split; red; intros;
-  repeat constructor.
-Qed.
-
 Lemma inverse_image_union2 {X Y : Type} (f : X -> Y) (U V : Ensemble Y) :
   inverse_image f (Union U V) = Union (inverse_image f U) (inverse_image f V).
 Proof.
@@ -361,7 +345,7 @@ Lemma inverse_image_finite {X Y : Type} (f : X -> Y) (F : Family X) :
 Proof.
 intros Hf H.
 induction H.
-- rewrite inverse_image_empty_set.
+- rewrite inverse_image_empty.
   constructor.
 - unfold Add.
   rewrite inverse_image_union2.

--- a/theories/ZornsLemma/Powerset_facts.v
+++ b/theories/ZornsLemma/Powerset_facts.v
@@ -79,3 +79,11 @@ apply Extensionality_Ensembles; split; red; intros.
 - contradict H. exists x. assumption.
 - destruct H0.
 Qed.
+
+Lemma Setminus_Intersection {X : Type} (U V : Ensemble X) :
+  Setminus U V = Intersection U (Complement V).
+Proof.
+apply Extensionality_Ensembles; split; red; intros.
+- destruct H. split; assumption.
+- destruct H. split; assumption.
+Qed.


### PR DESCRIPTION
What I consider most controversial of this PR is the renaming of `subspace_topology_topology` to `subspace_open_char` and using `<->` instead of `->`. The rest are minor changes adding smaller lemmas for later use or juggling code around to simplify or generalise it. The intentions etc are described in the commit messages.
Feel free to merge, if everything is acceptable.