### PR TITLE
Misc development

### DIFF
--- a/theories/Topology/Completion.v
+++ b/theories/Topology/Completion.v
@@ -148,7 +148,7 @@ cut (exists Y:Type, exists i:X->Y, exists d':Y->Y->R,
              unfold R_metric.
              rewrite (metric_sym _ _ d_metric x2 x1).
              rewrite Rminus_0_r.
-             symmetry; apply Rabs_right, d_metric.
+             symmetry; apply Rabs_right, metric_nonneg, d_metric.
       ** apply uniform_metric_complete.
          exact R_metric_complete.
   + exists False, (fun x:X => H (inhabits x)), (False_rect _).

--- a/theories/Topology/Continuity.v
+++ b/theories/Topology/Continuity.v
@@ -120,6 +120,21 @@ apply H0.
 apply H2.
 Qed.
 
+Lemma continuous_closed :
+  continuous <-> forall U, closed U -> closed (inverse_image f U).
+Proof.
+  split.
+  - intros. red.
+    rewrite <- inverse_image_complement.
+    apply H. assumption.
+  - intros.
+    red. intros.
+    apply closed_complement_open.
+    rewrite <- inverse_image_complement.
+    apply H. red. rewrite Complement_Complement.
+    assumption.
+Qed.
+
 End continuity.
 
 Arguments continuous {X} {Y}.

--- a/theories/Topology/Homeomorphisms.v
+++ b/theories/Topology/Homeomorphisms.v
@@ -57,6 +57,11 @@ rewrite H4.
 auto.
 Qed.
 
+Lemma homeomorphism_id (X : TopologicalSpace) : homeomorphism (@id X).
+Proof.
+  exists id; auto using continuous_identity.
+Qed.
+
 Inductive homeomorphic (X Y:TopologicalSpace) : Prop :=
 | intro_homeomorphic: forall f:point_set X -> point_set Y,
     homeomorphism f -> homeomorphic X Y.
@@ -67,9 +72,7 @@ From ZornsLemma Require Import Relation_Definitions_Implicit.
 Lemma homeomorphic_equiv: equivalence homeomorphic.
 Proof.
 constructor.
-- intro X.
-  exists id, id; trivial;
-    apply continuous_identity.
+- eexists; eapply homeomorphism_id.
 - intros X Y Z ? ?.
   destruct H as [f [finv]].
   destruct H0 as [g [ginv]].

--- a/theories/Topology/MetricSpaces.v
+++ b/theories/Topology/MetricSpaces.v
@@ -13,12 +13,22 @@ Variable X:Type.
 Variable d:X->X->R.
 
 Record metric : Prop := {
-  metric_nonneg: forall x y:X, d x y >= 0;
   metric_sym: forall x y:X, d x y = d y x;
   triangle_inequality: forall x y z:X, d x z <= d x y + d y z;
   metric_zero: forall x:X, d x x = 0;
   metric_strict: forall x y:X, d x y = 0 -> x = y
 }.
+
+Lemma metric_nonneg :
+  metric ->
+  forall x y : X, d x y >= 0.
+Proof.
+  intros.
+  pose proof (triangle_inequality H x y x).
+  rewrite (metric_sym H y x) in H0.
+  rewrite (metric_zero H) in H0.
+  lra.
+Qed.
 
 End metric.
 

--- a/theories/Topology/ProductTopology.v
+++ b/theories/Topology/ProductTopology.v
@@ -228,7 +228,7 @@ exact (weak_topology_makes_continuous_funcs
   _ _ _ prod2_proj twoT_2).
 Qed.
 
-Lemma product2_map_continuous: forall (W:TopologicalSpace)
+Lemma product2_map_continuous_at: forall (W:TopologicalSpace)
   (f:point_set W -> point_set X) (g:point_set W -> point_set Y)
   (w:point_set W),
   continuous_at f w -> continuous_at g w ->
@@ -251,6 +251,22 @@ replace (fun w:point_set W => (f w, g w)) with
   + apply product_map_continuous.
     now destruct a.
 - now extensionality w0.
+Qed.
+
+Corollary product2_map_continuous: forall (W:TopologicalSpace)
+  (f:point_set W -> point_set X) (g:point_set W -> point_set Y),
+  continuous f -> continuous g ->
+  continuous (fun w:point_set W => (f w, g w))
+  (Y:=ProductTopology2).
+Proof.
+  intros.
+  apply pointwise_continuity.
+  intros.
+  apply product2_map_continuous_at.
+  - apply continuous_func_continuous_everywhere.
+    assumption.
+  - apply continuous_func_continuous_everywhere.
+    assumption.
 Qed.
 
 Inductive ProductTopology2_basis :
@@ -386,5 +402,5 @@ apply (continuous_composition_at
   (fun p:point_set (ProductTopology2 X Y) =>
       let (x,y):=p in f x y)
   (fun w:point_set W => (g w, h w))); trivial.
-now apply product2_map_continuous.
+now apply product2_map_continuous_at.
 Qed.

--- a/theories/Topology/ProductTopology.v
+++ b/theories/Topology/ProductTopology.v
@@ -404,3 +404,20 @@ apply (continuous_composition_at
   (fun w:point_set W => (g w, h w))); trivial.
 now apply product2_map_continuous_at.
 Qed.
+
+Corollary continuous_composition_2arg:
+  forall {U X Y Z : TopologicalSpace} (f : U -> X) (g : U -> Y) (h : X -> Y -> Z),
+    continuous f -> continuous g -> continuous_2arg h ->
+    continuous (fun p => h (f p) (g p)).
+Proof.
+  intros.
+  apply pointwise_continuity.
+  intros.
+  apply continuous_composition_at_2arg.
+  - apply continuous_2arg_func_continuous_everywhere.
+    assumption.
+  - apply continuous_func_continuous_everywhere.
+    assumption.
+  - apply continuous_func_continuous_everywhere.
+    assumption.
+Qed.

--- a/theories/Topology/RFuncContinuity.v
+++ b/theories/Topology/RFuncContinuity.v
@@ -397,3 +397,103 @@ exists (fun x => (subspace_inc U x) / (1 - Rabs (subspace_inc U x))).
       apply Rle_ge.
       replace 0 with (0 * / (1-x)); auto with real.
 Qed.
+
+Lemma Rmin_using_Rabs x y :
+  Rmin x y = (x + y - Rabs (x-y))*(1/2).
+Proof.
+  destruct (classic (x <= y)).
+  - rewrite Rmin_left; try assumption.
+    rewrite Rabs_minus_sym.
+    rewrite Rabs_pos_eq.
+    2: { lra. }
+    lra.
+  - rewrite Rmin_right; try lra.
+    rewrite Rabs_pos_eq.
+    2: { lra. }
+    lra.
+Qed.
+
+Lemma Rmax_using_Rabs x y :
+  Rmax x y = (x + y + Rabs (x-y))*(1/2).
+Proof.
+  destruct (classic (x <= y)).
+  - rewrite Rmax_right; try assumption.
+    rewrite Rabs_minus_sym.
+    rewrite Rabs_pos_eq.
+    2: { lra. }
+    lra.
+  - rewrite Rmax_left; try lra.
+    rewrite Rabs_pos_eq.
+    2: { lra. }
+    lra.
+Qed.
+
+Lemma continuous_2arg_compose : forall {U X Y Z : TopologicalSpace} (f : U -> X) (g : U -> Y) (h : X -> Y -> Z),
+    continuous f -> continuous g -> continuous_2arg h ->
+    continuous (fun p => h (f p) (g p)).
+Proof.
+  intros.
+  apply pointwise_continuity.
+  intros.
+  apply continuous_composition_at_2arg.
+  - apply continuous_2arg_func_continuous_everywhere.
+    assumption.
+  - apply continuous_func_continuous_everywhere.
+    assumption.
+  - apply continuous_func_continuous_everywhere.
+    assumption.
+Qed.
+
+Lemma Rmin_continuous : continuous_2arg Rmin (X:=RTop) (Y:=RTop) (Z:=RTop).
+Proof.
+  red.
+  replace (fun p : RTop * RTop => _) with
+      (fun p : RTop * RTop => ((fst p) + (snd p) - Rabs (fst p - snd p))*(1/2)).
+  2: {
+    apply functional_extensionality.
+    intros []. simpl.
+    symmetry. apply Rmin_using_Rabs.
+  }
+  apply @continuous_2arg_compose with (X := RTop) (Y := RTop).
+  2: { apply continuous_constant. }
+  2: { apply Rmult_continuous. }
+  apply @continuous_2arg_compose with (X := RTop) (Y := RTop).
+  3: { apply Rminus_continuous. }
+  - apply @continuous_2arg_compose with (X := RTop) (Y := RTop).
+    + apply product2_fst_continuous.
+    + apply product2_snd_continuous.
+    + apply Rplus_continuous.
+  - apply @continuous_composition with (Y := RTop).
+    { apply Rabs_continuous. }
+    apply @continuous_2arg_compose with (X := RTop) (Y := RTop).
+    + apply product2_fst_continuous.
+    + apply product2_snd_continuous.
+    + apply Rminus_continuous.
+Qed.
+
+Lemma Rmax_continuous : continuous_2arg Rmax (X:=RTop) (Y:=RTop) (Z:=RTop).
+Proof.
+  red.
+  replace (fun p : RTop * RTop => _) with
+      (fun p : RTop * RTop => ((fst p) + (snd p) + Rabs (fst p - snd p))*(1/2)).
+  2: {
+    apply functional_extensionality.
+    intros []. simpl.
+    symmetry. apply Rmax_using_Rabs.
+  }
+  apply @continuous_2arg_compose with (X := RTop) (Y := RTop).
+  2: { apply continuous_constant. }
+  2: { apply Rmult_continuous. }
+  apply @continuous_2arg_compose with (X := RTop) (Y := RTop).
+  3: { apply Rplus_continuous. }
+  - apply @continuous_2arg_compose with (X := RTop) (Y := RTop).
+    + apply product2_fst_continuous.
+    + apply product2_snd_continuous.
+    + apply Rplus_continuous.
+  - apply @continuous_composition with (Y := RTop).
+    { apply Rabs_continuous. }
+    apply @continuous_2arg_compose with (X := RTop) (Y := RTop).
+    + apply product2_fst_continuous.
+    + apply product2_snd_continuous.
+    + apply Rminus_continuous.
+Qed.

--- a/theories/Topology/RTopology.v
+++ b/theories/Topology/RTopology.v
@@ -46,15 +46,6 @@ cut (y - z <= R_metric y z).
   apply Rle_abs.
 Qed.
 
-Lemma family_union_singleton
-  {X : Type}
-  (S : Ensemble X) :
-  FamilyUnion (Singleton S) = S.
-Proof.
-now extensionality_ensembles;
-  try econstructor.
-Qed.
-
 Lemma R_lower_beam_open : forall p,
   @open RTop [r : R | r < p].
 Proof.

--- a/theories/Topology/RTopology.v
+++ b/theories/Topology/RTopology.v
@@ -12,8 +12,6 @@ Proof.
 constructor;
   intros;
   unfold R_metric in *.
-- pose proof (Rabs_pos (y-x)).
-  auto with real.
 - replace (y-x) with (-(x-y)) by ring.
   apply Rabs_Ropp.
 - replace (z-x) with ((y-x) + (z-y)) by ring.

--- a/theories/Topology/TietzeExtension.v
+++ b/theories/Topology/TietzeExtension.v
@@ -485,7 +485,10 @@ Lemma Tietze_extension_func_is_extension:
 Proof.
 intros.
 apply R_metric_is_metric.
-apply Rle_antisym; try (apply Rge_le; apply R_metric_is_metric).
+apply Rle_antisym.
+2: {
+  apply Rge_le, metric_nonneg, R_metric_is_metric.
+}
 apply lt_plus_epsilon_le; intros.
 unfold Tietze_extension_func;
   destruct constructive_definite_description as [[g]]; simpl.

--- a/theories/Topology/TopologicalSpaces.v
+++ b/theories/Topology/TopologicalSpaces.v
@@ -123,6 +123,22 @@ rewrite Complement_Complement in H.
 assumption.
 Qed.
 
+Lemma closed_empty : forall {X : TopologicalSpace},
+    closed (@Empty_set X).
+Proof.
+  intros. red.
+  rewrite Complement_Empty_set.
+  apply open_full.
+Qed.
+
+Lemma closed_full : forall {X : TopologicalSpace},
+    closed (@Full_set X).
+Proof.
+  intros. red.
+  rewrite Complement_Full_set.
+  apply open_empty.
+Qed.
+
 Lemma closed_union2: forall {X:TopologicalSpace}
   (F G:Ensemble X),
   closed F -> closed G -> closed (Union F G).

--- a/theories/Topology/UniformTopology.v
+++ b/theories/Topology/UniformTopology.v
@@ -41,15 +41,6 @@ Lemma uniform_metric_is_metric: metric uniform_metric.
 Proof.
 constructor; intros.
 - unfold uniform_metric.
-  destruct x as [f0 Hf]; destruct y as [g0 Hg]; destruct sup.
-  simpl.
-  destruct X_inhabited as [x0].
-  apply Rge_trans with (d (f0 x0) (g0 x0)).
-  + cut (d (f0 x0) (g0 x0) <= x); auto with real.
-    apply i.
-    exists x0; auto with sets.
-  + apply d_metric.
-- unfold uniform_metric.
   destruct x as [f0 Hf]; destruct y as [g0 Hg].
   destruct sup.
   destruct sup.
@@ -113,7 +104,8 @@ constructor; intros.
   + apply i; exists x; trivial.
     constructor.
   + cut (d (f0 x) (g0 x) >= 0); auto with real.
-    apply d_metric.
+    apply metric_nonneg.
+    assumption.
 Qed.
 
 Definition UniformTopology : TopologicalSpace :=

--- a/theories/ZornsLemma/EnsemblesImplicit.v
+++ b/theories/ZornsLemma/EnsemblesImplicit.v
@@ -19,4 +19,4 @@ Arguments Extensionality_Ensembles {U}.
 Arguments Empty_set {U}.
 Arguments Full_set {U}.
 
-Hint Constructors Full_set : sets.
+Global Hint Constructors Full_set : sets.

--- a/theories/ZornsLemma/Families.v
+++ b/theories/ZornsLemma/Families.v
@@ -3,6 +3,7 @@ From Coq Require Import Classical_sets.
 From Coq Require Export Ensembles.
 From ZornsLemma Require Import EnsemblesImplicit.
 From ZornsLemma Require Export EnsemblesSpec.
+From ZornsLemma Require Import Image ImageImplicit.
 
 Set Implicit Arguments.
 
@@ -126,3 +127,22 @@ apply Extensionality_Ensembles; split; red; intros.
   assumption.
 Qed.
 End FamilyFacts.
+
+Lemma image_family_union (X Y : Type) (F : Family X) (f : X -> Y) :
+  Im (FamilyUnion F) f = FamilyUnion (Im F (fun U => Im U f)).
+Proof.
+apply Extensionality_Ensembles; split; red; intros.
+- inversion_clear H. subst.
+  inversion_clear H0.
+  exists (Im S f).
+  { exists S; auto. }
+  apply Im_def.
+  assumption.
+- inversion_clear H.
+  inversion_clear H0.
+  subst.
+  inversion_clear H1.
+  subst.
+  apply Im_def.
+  exists x0; auto.
+Qed.

--- a/theories/ZornsLemma/Families.v
+++ b/theories/ZornsLemma/Families.v
@@ -2,7 +2,7 @@ From Coq Require Import Classical_Prop.
 From Coq Require Import Classical_sets.
 From Coq Require Export Ensembles.
 From ZornsLemma Require Import EnsemblesImplicit.
-From ZornsLemma Require Export EnsemblesSpec.
+From ZornsLemma Require Export EnsemblesSpec EnsemblesTactics.
 From ZornsLemma Require Import Image ImageImplicit.
 
 Set Implicit Arguments.
@@ -145,4 +145,13 @@ apply Extensionality_Ensembles; split; red; intros.
   subst.
   apply Im_def.
   exists x0; auto.
+Qed.
+
+Lemma family_union_singleton
+  {X : Type}
+  (S : Ensemble X) :
+  FamilyUnion (Singleton S) = S.
+Proof.
+now extensionality_ensembles;
+  try econstructor.
 Qed.

--- a/theories/ZornsLemma/FiniteTypes.v
+++ b/theories/ZornsLemma/FiniteTypes.v
@@ -949,3 +949,33 @@ induction H.
   2: { assumption. }
   exists f; assumption.
 Qed.
+
+Lemma FiniteT_unit : FiniteT unit.
+Proof.
+  unshelve eapply bij_finite with (X := option False).
+  - intros. constructor.
+  - repeat constructor.
+  - unshelve econstructor.
+    + intros. exact None.
+    + intros. destruct x; intuition.
+    + intros. destruct y; intuition.
+Qed.
+
+Lemma FiniteT_bool : FiniteT bool.
+Proof.
+  unshelve eapply bij_finite with (X := option (option False)).
+  - intros.
+    refine (match H with
+            | None => true
+            | Some _ => false
+            end).
+  - repeat constructor.
+  - unshelve econstructor.
+    + intros.
+      apply (match H with
+             | true => None
+             | false => Some None
+             end).
+    + intros. destruct x as [[]|]; intuition.
+    + intros. destruct y as [|]; intuition.
+Qed.

--- a/theories/ZornsLemma/IndexedFamilies.v
+++ b/theories/ZornsLemma/IndexedFamilies.v
@@ -22,8 +22,6 @@ Inductive IndexedIntersection : Ensemble T :=
 
 End IndexedFamilies.
 
-Section IndexedFamilyFacts.
-
 (* unions and intersections over subsets of the index set *)
 Lemma sub_indexed_union: forall {A B T:Type} (f:A->B)
   (F:IndexedFamily B T),
@@ -175,7 +173,20 @@ apply Extensionality_Ensembles; split; red; intros.
   subst. apply H0.
 Qed.
 
-End IndexedFamilyFacts.
+Lemma image_indexed_union (X Y I : Type) (F : IndexedFamily I X) (f : X -> Y) :
+  Im (IndexedUnion F) f = IndexedUnion (fun i => Im (F i) f).
+Proof.
+apply Extensionality_Ensembles; split; red; intros.
+- inversion H; subst; clear H.
+  inversion H0; subst; clear H0.
+  exists a.
+  exists x0.
+  all: auto.
+- inversion H; subst; clear H.
+  inversion H0; subst; clear H0.
+  exists x0; [|reflexivity].
+  exists a. assumption.
+Qed.
 
 Section IndexedFamilyToFamily.
 

--- a/theories/ZornsLemma/WellOrders.v
+++ b/theories/ZornsLemma/WellOrders.v
@@ -1,12 +1,8 @@
 From Coq Require Export Relation_Definitions.
-From ZornsLemma Require Import Relation_Definitions_Implicit.
-From ZornsLemma Require Import Classical_Wf.
-From Coq Require Import Description.
-From Coq Require Import FunctionalExtensionality.
-From Coq Require Import Classical.
-From ZornsLemma Require Import ZornsLemma.
-From Coq Require Import ProofIrrelevance.
-From ZornsLemma Require Import EnsemblesSpec.
+From Coq Require Import Classical Description
+     FunctionalExtensionality ProofIrrelevance.
+From ZornsLemma Require Import Classical_Wf EnsemblesSpec
+     Relation_Definitions_Implicit ZornsLemma.
 
 Section WellOrder.
 


### PR DESCRIPTION
I made some changes to the library, some of them are minor breaking changes.

### Breaking changes for users of the library:
* Rename `product2_map_continuous` to `product2_map_continous_at`
* Show that `metric_nonneg` is admissible and remove it from the `metric` structure.

### Additions:
* Lemmas for `closed Empty_set` and `closed Full_set`
* Characterize continuity via closed sets
* Describe how `Im` commutes with `IndexedUnion` and `FamilyUnion`
* Prove that `bool` and `unit` are finite types
* Prove that `Rmin` and `Rmax` are continuous, via `Rabs`

### Minor changes:
* Moving a lemma from RTopology.v to Families.v
* Reorder imports in WellOrders.v
* Extract the lemma that `id` is a homeomorphism from another proof.