### PR TITLE
Start a typeclass hierarchy of topological properties

### DIFF
--- a/theories/Topology/Compactness.v
+++ b/theories/Topology/Compactness.v
@@ -493,8 +493,8 @@ repeat split.
     now subst.
 Qed.
 
-Instance compact_Hausdorff_impl_T3_sep: forall X:TopologicalSpace,
-  compact X -> Hausdorff X -> T3_space X.
+Instance compact_Hausdorff_is_T3_space {X:TopologicalSpace}
+         (H : compact X) `(H0 : Hausdorff X) : T3_space X.
 Proof.
 intros X HX_compact HX_Hausdorff.
 split.

--- a/theories/Topology/Compactness.v
+++ b/theories/Topology/Compactness.v
@@ -493,12 +493,12 @@ repeat split.
     now subst.
 Qed.
 
-Lemma compact_Hausdorff_impl_T3_sep: forall X:TopologicalSpace,
-  compact X -> Hausdorff X -> T3_sep X.
+Instance compact_Hausdorff_impl_T3_sep: forall X:TopologicalSpace,
+  compact X -> Hausdorff X -> T3_space X.
 Proof.
 intros X HX_compact HX_Hausdorff.
 split.
-{ now apply Hausdorff_impl_T1_sep. }
+{ typeclasses eauto. }
 intros x F HF HFx.
 pose (P := fun y => (fun p : Ensemble X * Ensemble X =>
                     open (fst p) /\ open (snd p) /\
@@ -514,7 +514,7 @@ assert (forall V, In cover_of_F V -> open V) as Hcover_open.
 destruct (closed_compact_ens X F HX_compact HF cover_of_F) as
   [fincover [Hfincover0 [Hfincover1 Hfincover2]]]; auto.
 { intros y Hy.
-  specialize (HX_Hausdorff x y) as [U [V [HU [HV [HUx [HVx0]]]]]].
+  specialize (hausdorff x y) as [U [V [HU [HV [HUx [HVx0]]]]]].
   { intros ?. subst. contradiction. }
   exists V; auto.
   exists U, y.
@@ -546,12 +546,11 @@ rewrite <- H3.
 split; assumption.
 Qed.
 
-Lemma compact_Hausdorff_impl_normal_sep: forall X:TopologicalSpace,
-  compact X -> Hausdorff X -> normal_sep X.
+Instance compact_T1_T3_space_is_normal_space
+  {X:TopologicalSpace} (HX_compact : compact X) `(HX_T1 : T1_space X)
+  `(HX_T3 : T3_space X) :
+  normal_space X.
 Proof.
-intros X HX_compact HX_Hausdorff.
-apply compact_Hausdorff_impl_T3_sep in HX_Hausdorff as [HX_T1 HX_regular];
-  try assumption.
 split; try assumption.
 intros F G HF_closed HG_closed HFG_disjoint.
 pose (P := fun y => (fun p : Ensemble X * Ensemble X =>
@@ -568,7 +567,7 @@ assert (forall U, In cover_of_F U -> open U) as Hcover_open.
 destruct (closed_compact_ens X F HX_compact HF_closed cover_of_F) as
   [fincover [Hfincover0 [Hfincover1 Hfincover2]]]; auto.
 { intros y Hy.
-  specialize (HX_regular y G) as [U [V [HU [HV [HUx [HVx0]]]]]];
+  specialize (T3_sep y G) as [U [V [HU [HV [HUx [HVx0]]]]]];
     auto.
   { intros ?.
     assert (In Empty_set y); try contradiction.

--- a/theories/Topology/Compactness.v
+++ b/theories/Topology/Compactness.v
@@ -685,3 +685,25 @@ Proof.
   apply compact_closed; auto.
   apply compact_image_ens; assumption.
 Qed.
+
+Lemma compact_inhabited_dec (X : TopologicalSpace) :
+  compact X -> inhabited X \/ ~ inhabited X.
+Proof.
+  intros Hcomp.
+  specialize (Hcomp (fun U => open U /\ Inhabited U)) as [Fam [H0 [H1 H2]]].
+  { intros ? []; auto. }
+  { extensionality_ensembles; try constructor.
+    exists Full_set; constructor.
+    - apply open_full.
+    - exists x. constructor.
+  }
+  destruct H0.
+  - right. intros ?.
+    destruct H as [x].
+    rewrite empty_family_union in H2.
+    pose proof (Full_intro _ x).
+    rewrite <- H2 in H. contradiction.
+  - left.
+    specialize (H1 x ltac:(right; reflexivity)) as [].
+    destruct H3. constructor. exact x0.
+Qed.

--- a/theories/Topology/Completeness.v
+++ b/theories/Topology/Completeness.v
@@ -159,11 +159,8 @@ cut (Included (closure F (X:=MetricTopology d d_metric)) F).
   { assert (uniqueness (net_limit y (I:=nat_DS)
                             (X:=MetricTopology d d_metric))).
   { apply Hausdorff_impl_net_limit_unique.
-    apply T3_sep_impl_Hausdorff.
-    apply normal_sep_impl_T3_sep.
-    apply metrizable_impl_normal_sep.
-    exists d; trivial.
-    apply MetricTopology_metrized. }
+    apply metrizable_Hausdorff.
+    apply MetricTopology_metrizable. }
     now apply H7. }
     now rewrite H7.
   + apply metric_space_net_limit with d.

--- a/theories/Topology/Completeness.v
+++ b/theories/Topology/Completeness.v
@@ -45,11 +45,27 @@ Lemma cauchy_sequence_with_cluster_point_converges:
 Proof.
 intros.
 apply metric_space_net_limit with d.
-- apply MetricTopology_metrized.
-- intros.
-  red; intros.
-  destruct (H (eps/2)) as [N].
+{ apply MetricTopology_metrized. }
+intros.
+red; intros.
+destruct (H (eps/2)) as [N].
+{ lra. }
+pose (U := open_ball X d x0 (eps/2)).
+assert (open_neighborhood U x0 (X:=MetricTopology d d_metric)).
+{ apply metric_space_open_ball_open_nbhd.
+  - apply MetricTopology_metrized.
+  - lra.
+}
+destruct H3.
+destruct (H0 U H3 H4 N) as [m [? []]].
+simpl in H5.
+exists N; intros n ?.
+simpl in H7.
+apply Rle_lt_trans with (d x0 (x m) + d (x m) (x n)).
+- now apply triangle_inequality.
+- cut (d (x m) (x n) < eps/2).
   + lra.
+<<<<<<< HEAD
   + pose (U := open_ball d x0 (eps/2)).
     assert (open_neighborhood U x0 (X:=MetricTopology d d_metric)).
   { apply MetricTopology_metrized.
@@ -65,6 +81,9 @@ apply metric_space_net_limit with d.
     * cut (d (x m) (x n) < eps/2).
       ** lra.
       ** now apply H2.
+=======
+  + now apply H2.
+>>>>>>> c692022 (Implement `metrizable` as typeclass)
 Qed.
 
 Definition complete : Prop :=
@@ -159,8 +178,8 @@ cut (Included (closure F (X:=MetricTopology d d_metric)) F).
   { assert (uniqueness (net_limit y (I:=nat_DS)
                             (X:=MetricTopology d d_metric))).
   { apply Hausdorff_impl_net_limit_unique.
-    apply metrizable_Hausdorff.
-    apply MetricTopology_metrizable. }
+    typeclasses eauto.
+  }
     now apply H7. }
     now rewrite H7.
   + apply metric_space_net_limit with d.

--- a/theories/Topology/InteriorsClosures.v
+++ b/theories/Topology/InteriorsClosures.v
@@ -88,6 +88,13 @@ Qed.
 
 End interior_closure.
 
+Lemma closure_empty {X:TopologicalSpace} :
+  closure (@Empty_set X) = Empty_set.
+Proof.
+  apply closure_fixes_closed.
+  apply closed_empty.
+Qed.
+
 Section interior_closure_relations.
 
 Definition idempotent {T:Type} (f:T->T) := forall x, f (f x) = f x.

--- a/theories/Topology/OrderTopology.v
+++ b/theories/Topology/OrderTopology.v
@@ -87,9 +87,9 @@ exists ([z:X | R z x /\ z <> x]);
   now subst.
 Qed.
 
-Lemma order_topology_Hausdorff: Hausdorff OrderTopology.
+Instance order_topology_Hausdorff: Hausdorff OrderTopology.
 Proof.
-red.
+constructor.
 match goal with |- forall x y:point_set OrderTopology, ?P =>
   cut (forall x y:point_set OrderTopology, R x y -> P)
   end;

--- a/theories/Topology/ProductTopology.v
+++ b/theories/Topology/ProductTopology.v
@@ -390,20 +390,22 @@ apply ProductTopology2_basis_is_basis.
 constructor; assumption.
 Qed.
 
-Lemma Hausdorff_ProductTopology2 {X Y : TopologicalSpace} :
+Instance Hausdorff_ProductTopology2 {X Y : TopologicalSpace} :
   Hausdorff X -> Hausdorff Y ->
   Hausdorff (ProductTopology2 X Y).
 Proof.
-  intros HX HY [x0 y0] [x1 y1] Hxy.
-  specialize (HX x0 x1).
-  specialize (HY y0 y1).
+  intros HX HY.
+  constructor.
+  intros [x0 y0] [x1 y1] Hxy.
+  pose proof (hausdorff x0 x1) as Hxx.
+  pose proof (hausdorff y0 y1) as Hyy.
   (* Is there some "symmetry" that can be used, so the proof doesn't
      contain redundant parts? *)
   destruct (classic (x0 = x1)) as [|Hx].
   { subst.
     assert (y0 <> y1) as Hy by congruence.
     clear Hxy.
-    specialize (HY Hy) as [U [V [HU [HV [HU0 [HV0 HUV]]]]]].
+    specialize (Hyy Hy) as [U [V [HU [HV [HU0 [HV0 HUV]]]]]].
     exists (EnsembleProduct Full_set U), (EnsembleProduct Full_set V).
     repeat split; auto using EnsembleProduct_open, open_full.
     simpl.
@@ -413,7 +415,7 @@ Proof.
     apply EnsembleProduct_Empty_r.
   }
   clear Hxy.
-  specialize (HX Hx) as [U [V [HU [HV [HU0 [HV0 HUV]]]]]].
+  specialize (Hxx Hx) as [U [V [HU [HV [HU0 [HV0 HUV]]]]]].
   exists (EnsembleProduct U Full_set), (EnsembleProduct V Full_set).
   repeat split; auto using EnsembleProduct_open, open_full.
   simpl.

--- a/theories/Topology/RTopology.v
+++ b/theories/Topology/RTopology.v
@@ -165,7 +165,7 @@ constructor;
     now apply H.
 Qed.
 
-Corollary RTop_metrizable: metrizable RTop.
+Instance RTop_metrizable: metrizable RTop.
 Proof.
 exists R_metric.
 - exact R_metric_is_metric.

--- a/theories/Topology/SubspaceTopology.v
+++ b/theories/Topology/SubspaceTopology.v
@@ -1,5 +1,7 @@
-Require Export TopologicalSpaces.
-Require Import WeakTopology.
+From Coq Require Import Program.Subset.
+From Topology Require Export TopologicalSpaces.
+From Topology Require Import Completeness MetricSpaces SeparatednessAxioms
+                             WeakTopology.
 
 Section Subspace.
 
@@ -113,4 +115,132 @@ apply Extensionality_Ensembles; split; red; intros.
   absurd (In (Complement G) (exist _ y i)).
   + now intro.
   + now rewrite H1.
+Qed.
+
+Instance T0_space_hereditary {X:TopologicalSpace} `(T0_space X) (A : Ensemble X) :
+  T0_space (SubspaceTopology A).
+Proof.
+  constructor. intros.
+  destruct (T0_sep (proj1_sig x) (proj1_sig y))
+           as [[U [? []]]|[U [? []]]].
+  { intros ?. apply subset_eq in H1. tauto. }
+  - left. exists (inverse_image (subspace_inc A) U).
+    repeat split.
+    + apply subspace_inc_continuous; assumption.
+    + assumption.
+    + intros ?. destruct H4. tauto.
+  - right. exists (inverse_image (subspace_inc A) U).
+    repeat split.
+    + apply subspace_inc_continuous; assumption.
+    + intros ?. destruct H4. tauto.
+    + assumption.
+Qed.
+
+Instance T1_space_hereditary {X:TopologicalSpace} `(T1_space X) (A : Ensemble X) :
+  T1_space (SubspaceTopology A).
+Proof.
+  constructor.
+  intros.
+  rewrite subspace_closed_char.
+  exists (Singleton (proj1_sig x)).
+  split.
+  - apply T1_sep.
+  - extensionality_ensembles_inv.
+    + constructor. constructor.
+    + apply subset_eq in H2 as [].
+      constructor.
+Qed.
+
+Instance Hausdorff_hereditary {X:TopologicalSpace} `(Hausdorff X) (A : Ensemble X) :
+  Hausdorff (SubspaceTopology A).
+Proof.
+  constructor.
+  intros.
+  destruct (hausdorff (proj1_sig x) (proj1_sig y))
+           as [U [V [? [? [? []]]]]].
+  { intros ?. apply subset_eq in H1. tauto. }
+  exists (inverse_image (subspace_inc A) U),
+    (inverse_image (subspace_inc A) V).
+  repeat split.
+  - apply subspace_inc_continuous; assumption.
+  - apply subspace_inc_continuous; assumption.
+  - assumption.
+  - assumption.
+  - rewrite <- inverse_image_intersection.
+    rewrite H5.
+    apply inverse_image_empty.
+Qed.
+
+Instance T3_space_hereditary {X:TopologicalSpace} `(T3_space X)
+         (A : Ensemble X) :
+  T3_space (SubspaceTopology A).
+Proof.
+  split.
+  { apply T1_space_hereditary. apply H. }
+  intros.
+  rewrite subspace_closed_char in H0.
+  destruct H0 as [D []].
+  subst.
+  assert (~ In D (proj1_sig x)).
+  { intros ?. apply H1. constructor. assumption. }
+  clear H1.
+  destruct (T3_sep (proj1_sig x) D)
+    as [U [V [? [? [? []]]]]];
+    try assumption.
+  exists (inverse_image (subspace_inc _) U).
+  exists (inverse_image (subspace_inc _) V).
+  repeat split.
+  - apply subspace_inc_continuous; assumption.
+  - apply subspace_inc_continuous; assumption.
+  - assumption.
+  - destruct H7. apply H5. assumption.
+  - rewrite <- inverse_image_intersection.
+    rewrite H6. apply inverse_image_empty.
+Qed.
+
+
+(* Side note: only [metric_zero] was important here. As long as [metrizes _ _] holds,
+   this proof could go through for non-metrizable spaces.
+*)
+Lemma metric_restriction_metrizes_subspace {X:TopologicalSpace} (d:X->X->R) A :
+  metrizes X d -> metric d ->
+  metrizes (SubspaceTopology A) (fun x y => d (proj1_sig x) (proj1_sig y)).
+Proof.
+  intros.
+  constructor.
+  - intros. inversion_clear H1.
+    split.
+    + rewrite subspace_open_char.
+      exists (open_ball X d (proj1_sig x) r).
+      split.
+      { apply metric_space_open_ball_open; assumption. }
+      extensionality_ensembles_inv;
+        repeat constructor; assumption.
+    + constructor.
+      rewrite metric_zero; auto.
+  - intros.
+    destruct H1.
+    rewrite subspace_open_char in H1.
+    destruct H1 as [U0 []]. subst.
+    destruct H2.
+    destruct (open_neighborhood_basis_cond
+                _ (proj1_sig x) (H (proj1_sig x)) U0)
+             as [V0 []].
+    { split; assumption. }
+    inversion H3; subst; clear H3.
+    exists (open_ball _ (fun x y => d (proj1_sig x) (proj1_sig y)) x r).
+    repeat split; try assumption.
+    apply H4. constructor.
+    destruct H3.
+    assumption.
+Qed.
+
+Instance metrizable_hereditary {X:TopologicalSpace} `(metrizable X) (A : Ensemble X) :
+  metrizable (SubspaceTopology A).
+Proof.
+  destruct H as [d ?Hd ?Hd].
+  exists (fun x y => d (proj1_sig x) (proj1_sig y)).
+  - apply d_restriction_metric. assumption.
+  - apply metric_restriction_metrizes_subspace;
+      assumption.
 Qed.

--- a/theories/Topology/TietzeExtension.v
+++ b/theories/Topology/TietzeExtension.v
@@ -646,12 +646,8 @@ destruct (UrysohnsLemma _ H G F) as [phi [? [? []]]]; trivial.
 - replace G with (inverse_image g0 (Union (Singleton 1) (Singleton (-1)))).
   + red. rewrite <- inverse_image_complement.
     apply H3.
-    assert (T1_space RTop) as HRT1.
-    { apply Hausdorff_is_T1_space.
-      apply metrizable_Hausdorff.
-      apply RTop_metrizable.
-    }
-    apply (closed_union2 (X:=RTop)); apply HRT1.
+    apply (closed_union2 (X:=RTop)); apply (@T1_sep RTop);
+      typeclasses eauto.
   + extensionality_ensembles_inv;
       constructor.
     * now left.

--- a/theories/Topology/TietzeExtension.v
+++ b/theories/Topology/TietzeExtension.v
@@ -409,9 +409,7 @@ split.
   apply H.
   exact extension_approximation_seq_cauchy.
 - apply Hausdorff_impl_net_limit_unique.
-  apply T3_sep_impl_Hausdorff.
-  apply normal_sep_impl_T3_sep.
-  apply metrizable_impl_normal_sep.
+  apply metrizable_Hausdorff.
   exists (uniform_metric R_metric (fun _:X => 0)
             R_metric_is_metric X_nonempty).
   + apply (uniform_metric_is_metric _ _ R_metric (fun _:X => 0)
@@ -582,7 +580,7 @@ End Tietze_extension_construction.
 
 Lemma bounded_Tietze_extension_theorem: forall (X:TopologicalSpace)
   (F:Ensemble X) (f:SubspaceTopology F -> RTop),
-  normal_sep X -> closed F -> continuous f ->
+  normal_space X -> closed F -> continuous f ->
   (forall x:SubspaceTopology F, -1 <= f x <= 1) ->
   exists g:X -> RTop,
     continuous g /\ (forall x:SubspaceTopology F,
@@ -632,7 +630,7 @@ Qed.
 
 Lemma open_bounded_Tietze_extension_theorem: forall (X:TopologicalSpace)
   (F:Ensemble X) (f:SubspaceTopology F -> RTop),
-  normal_sep X -> closed F -> continuous f ->
+  normal_space X -> closed F -> continuous f ->
   (forall x:SubspaceTopology F, -1 < f x < 1) ->
   exists g:X -> RTop,
     continuous g /\ (forall x:SubspaceTopology F,
@@ -648,10 +646,12 @@ destruct (UrysohnsLemma _ H G F) as [phi [? [? []]]]; trivial.
 - replace G with (inverse_image g0 (Union (Singleton 1) (Singleton (-1)))).
   + red. rewrite <- inverse_image_complement.
     apply H3.
-    apply (closed_union2 (X:=RTop)); apply Hausdorff_impl_T1_sep;
-      apply T3_sep_impl_Hausdorff; apply normal_sep_impl_T3_sep;
-      apply metrizable_impl_normal_sep; exists R_metric;
-      (apply R_metric_is_metric || apply RTop_metrization).
+    assert (T1_space RTop) as HRT1.
+    { apply Hausdorff_is_T1_space.
+      apply metrizable_Hausdorff.
+      apply RTop_metrizable.
+    }
+    apply (closed_union2 (X:=RTop)); apply HRT1.
   + extensionality_ensembles_inv;
       constructor.
     * now left.
@@ -708,7 +708,7 @@ Qed.
 
 Theorem Tietze_extension_theorem: forall (X:TopologicalSpace)
   (F:Ensemble X) (f:SubspaceTopology F -> RTop),
-  normal_sep X -> closed F -> continuous f ->
+  normal_space X -> closed F -> continuous f ->
   exists g:X -> RTop,
     continuous g /\ (forall x:SubspaceTopology F,
                      g (subspace_inc F x) = f x).

--- a/theories/Topology/TopologicalSpaces.v
+++ b/theories/Topology/TopologicalSpaces.v
@@ -209,6 +209,15 @@ rewrite Complement_IndexedUnion.
 apply open_finite_indexed_intersection; trivial.
 Qed.
 
+Lemma open_setminus {X : TopologicalSpace} (U V : Ensemble X) :
+  open U -> closed V ->
+  open (Setminus U V).
+Proof.
+  intros.
+  rewrite Setminus_Intersection.
+  apply open_intersection2; assumption.
+Qed.
+
 Global Hint Unfold closed : topology.
 Global Hint Resolve open_family_union open_intersection2 open_full
   open_empty open_union2 open_indexed_union

--- a/theories/Topology/UniformTopology.v
+++ b/theories/Topology/UniformTopology.v
@@ -123,10 +123,8 @@ assert (forall y:Net nat_DS (MetricTopology d d_metric), cauchy d y ->
   apply -> unique_existence; split.
   - apply H; trivial.
   - apply (Hausdorff_impl_net_limit_unique y).
-    apply T3_sep_impl_Hausdorff.
-    apply normal_sep_impl_T3_sep.
-    apply metrizable_impl_normal_sep.
-    exists d; trivial; apply MetricTopology_metrized.
+    apply metrizable_Hausdorff.
+    apply MetricTopology_metrizable.
 }
 red; intros f ?.
 unshelve refine (let H1 := _ in let H2 := _ in ex_intro _

--- a/theories/Topology/UrysohnsLemma.v
+++ b/theories/Topology/UrysohnsLemma.v
@@ -711,17 +711,34 @@ Qed.
 
 End Urysohns_Lemma_construction.
 
-Theorem UrysohnsLemma: forall X:TopologicalSpace, normal_sep X ->
-  forall F G:Ensemble X,
+Theorem UrysohnsLemma: forall X:TopologicalSpace, normal_space X ->
+  forall F G:Ensemble (point_set X),
   closed F -> closed G -> Intersection F G = Empty_set ->
   exists f:X -> RTop,
   continuous f /\ (forall x:X, 0 <= f x <= 1) /\
   (forall x:X, In F x -> f x = 0) /\
   (forall x:X, In G x -> f x = 1).
 Proof.
-intros X [_ HX_normal] F G HF HG HFG.
-destruct (HX_normal F G HF HG HFG) as [U [V [HU [HV [HFU [HGV HUV]]]]]].
-assert (inhabited (forall F U:Ensemble X, closed F ->
+intros.
+destruct H.
+destruct (normal_sep F G H0 H1 H2) as [U [V [? [? [? [? ?]]]]]].
+assert (Included (closure U) (Complement G)).
+{ assert (Included (closure U) (Complement V)).
+  { apply closure_minimal.
+    - red. now rewrite Complement_Complement.
+    - red. intros.
+      intro.
+      eapply Noone_in_empty.
+      rewrite <- H6.
+      econstructor;
+        eassumption. }
+  assert (Included (Complement V) (Complement G)).
+  { red. intros.
+    intro.
+    contradiction H8.
+    now apply H5. }
+  auto with sets. }
+assert (inhabited (forall F U:Ensemble (point_set X), closed F ->
   open U -> Included F U ->
   { V:Ensemble X | open V /\ Included F V /\
                                Included (closure V) U }))
@@ -732,60 +749,46 @@ assert (inhabited (forall F U:Ensemble X, closed F ->
     (V0:Ensemble X) =>
      open V0 /\ Included (fst (proj1_sig FU_pair)) V0 /\
      Included (closure V0) (snd (proj1_sig FU_pair)))) as
-    [pre_choice_fun Hpre_choice_fun].
-  2: {
-    exists.
-    intros F0 U0 HF0 HU0 HF0U0.
+    [pre_choice_fun].
+  - intro p.
+    destruct p as [[F0 U0]].
+    simpl in a.
+    simpl.
+    destruct a as [? []].
+    destruct (normal_sep F0 (Complement U0)) as [U1 [V1 []]]; trivial.
+    + red. now rewrite Complement_Complement.
+    + extensionality_ensembles_inv.
+      contradiction H13.
+      now apply H10.
+    + destruct H12 as [? [? []]].
+      exists U1.
+      repeat split; trivial.
+      assert (Included (closure U1) (Complement V1)).
+      { apply closure_minimal.
+        - red. now rewrite Complement_Complement.
+        - red. intros.
+          intro.
+          eapply Noone_in_empty.
+          rewrite <- H15.
+          constructor;
+            eassumption. }
+      assert (Included (Complement V1) U0).
+      { red. intros.
+        apply NNPP. intro.
+        contradiction H17.
+        now apply H14. }
+      auto with sets.
+  - exists.
+    intros.
     exists (pre_choice_fun (exist _ (F0,U0)
-      (conj HF0 (conj HU0 HF0U0)))).
-    apply Hpre_choice_fun. }
-  intros [[F0 U0] [HF0 [HU0 HF0U0]]].
-  simpl in *.
-  destruct (HX_normal F0 (Complement U0))
-    as [U1 [V1 [? [? [? [H_CU0_V1 HU1V1]]]]]]; trivial.
-  { red. now rewrite Complement_Complement. }
-  { extensionality_ensembles_inv.
-    subst.
-    match goal with
-    | H : In F0 _ |- _ =>
-      apply HF0U0 in H
-    end.
-    contradiction. }
-  exists U1.
-  repeat split; trivial.
-  transitivity (Complement V1).
-  - apply closure_minimal.
-    + red. now rewrite Complement_Complement.
-    + red. intros.
-      intro.
-      eapply Noone_in_empty.
-      rewrite <- HU1V1.
-      constructor;
-        eassumption.
-  - red. intros.
-    apply NNPP. intros Hx.
-    apply H_CU0_V1 in Hx.
-    contradiction. }
+      (conj H9 (conj H10 H11)))).
+    apply H8. }
 unshelve eexists (Urysohns_Lemma_function _ normal_sep_fun
-  U (Complement G) HU HG _).
-{ transitivity (Complement V).
-  - apply closure_minimal.
-    + red. now rewrite Complement_Complement.
-    + red. intros.
-      intro.
-      eapply Noone_in_empty.
-      rewrite <- HUV.
-      econstructor;
-        eassumption.
-  - red. intros x Hx ?.
-    contradiction Hx.
-    now apply HGV. }
-split.
-{ apply Urysohns_Lemma_function_continuous. }
-split.
-{ apply Urysohns_Lemma_function_range. }
-split;
-  intros.
-- apply Urysohns_Lemma_function_0; auto.
-- apply Urysohns_Lemma_function_1; auto.
+  U (Complement G) _ _ _); try assumption.
+repeat split.
+- apply Urysohns_Lemma_function_continuous.
+- apply Urysohns_Lemma_function_range.
+- apply Urysohns_Lemma_function_range.
+- intros. apply Urysohns_Lemma_function_0; auto.
+- intros. apply Urysohns_Lemma_function_1; auto.
 Qed.

--- a/theories/ZornsLemma/FiniteTypes.v
+++ b/theories/ZornsLemma/FiniteTypes.v
@@ -816,6 +816,28 @@ Proof.
         assumption.
 Qed.
 
+Corollary FiniteT_dec_Finite X (U : Ensemble X) :
+  FiniteT X ->
+  (forall x : X, In U x \/ ~ In U x) ->
+  Finite U.
+Proof.
+  intros.
+  apply FiniteT_dec_Ensemble_has_cardinal in H0;
+    try assumption.
+  destruct H0 as [n].
+  apply cardinal_finite with (n := n).
+  assumption.
+Qed.
+
+Corollary FiniteT_Finite X (U : Ensemble X) :
+  FiniteT X -> Finite U.
+Proof.
+  intros.
+  apply FiniteT_dec_Finite;
+    try assumption.
+  intros. apply classic.
+Qed.
+
 Corollary FiniteT_has_nat_cardinal' (X : Type) :
   FiniteT X ->
   exists n, cardinal X Full_set n.

--- a/theories/ZornsLemma/FiniteTypes.v
+++ b/theories/ZornsLemma/FiniteTypes.v
@@ -737,18 +737,103 @@ induction H.
     rewrite H2; reflexivity.
 Qed.
 
-Lemma FiniteT_has_nat_cardinal: forall X:Type, FiniteT X ->
-  exists! n:nat, cardinal _ (@Full_set X) n.
+Lemma injection_preserves_cardinal: forall (X Y:Type)
+  (f:X->Y) (n:nat) (S:Ensemble X), cardinal _ S n ->
+  injective f -> cardinal _ (Im S f) n.
+Proof.
+intros.
+induction H.
+- rewrite image_empty.
+  constructor.
+- rewrite Im_add.
+  constructor; trivial.
+  red; intro H3; inversion H3.
+  subst. apply H0 in H4. subst.
+  contradiction.
+Qed.
+
+Lemma FiniteT_dec_Ensemble_has_cardinal X U :
+  FiniteT X ->
+  (forall x, In U x \/ ~ In U x) ->
+  exists n, cardinal X U n.
+Proof.
+  intros.
+  generalize dependent U.
+  induction H.
+  - intros. exists 0.
+    pose proof (False_Ensembles_eq U Empty_set).
+    subst.
+    constructor.
+  - intros.
+    specialize (IHFiniteT
+                  (fun t : T =>
+                     In U (Some t))).
+    destruct IHFiniteT as [m].
+    { intros. unfold In at 1 3.
+      apply H0.
+    }
+    specialize (H0 None) as [|].
+    + exists (S m).
+      replace U with (Add (Im (fun t : T => In U (Some t)) Some) None).
+      1: constructor.
+      1: apply injection_preserves_cardinal.
+      * assumption.
+      * red; intros; congruence.
+      * intros ?. inversion H2; subst; clear H2. congruence.
+      * extensionality_ensembles; try (subst; assumption).
+        destruct x.
+        -- left. exists t; auto.
+        -- right. constructor.
+    + exists m.
+      replace U with (Im (fun t : T => In U (Some t)) Some).
+      1: apply injection_preserves_cardinal.
+      1: assumption.
+      1: red; intros; congruence.
+      extensionality_ensembles.
+      * subst. assumption.
+      * destruct x; try contradiction.
+        exists t; auto.
+  - intros.
+    specialize (IHFiniteT
+                  (fun x : X =>
+                     In U (f x))).
+    destruct IHFiniteT as [m].
+    { intros. unfold In at 1 3.
+      apply H1.
+    }
+    exists m.
+    replace U with (Im (fun x : X => In U (f x)) f).
+    1: apply injection_preserves_cardinal.
+    1: assumption.
+    + red; intros.
+      apply invertible_impl_bijective in H0.
+      destruct H0. apply H0 in H3. assumption.
+    + extensionality_ensembles.
+      * subst. assumption.
+      * destruct H0.
+        exists (g x); auto.
+        unfold In at 1. rewrite H4.
+        assumption.
+Qed.
+
+Corollary FiniteT_has_nat_cardinal' (X : Type) :
+  FiniteT X ->
+  exists n, cardinal X Full_set n.
+Proof.
+  intros.
+  apply FiniteT_dec_Ensemble_has_cardinal;
+    [assumption|].
+  intros. left. constructor.
+Qed.
+
+Corollary FiniteT_has_nat_cardinal (X : Type) :
+  FiniteT X ->
+  exists! n:nat, cardinal X (@Full_set X) n.
 Proof.
 intros.
 apply -> unique_existence; split.
-- apply finite_cardinal.
-  rewrite Im_Full_set_surj with id.
-  2: { apply id_bijective. }
-  apply FiniteT_img with (f:=fun x:X => x).
-  + assumption.
-  + intros.
-    case (finite_eq_dec X H y1 y2); tauto.
+- apply FiniteT_has_nat_cardinal'.
+  assumption.
 - red; intros.
   apply cardinal_unicity with X Full_set; trivial.
 Qed.
@@ -785,21 +870,6 @@ Proof.
 apply FiniteT_nat_cardinal_cond.
 rewrite (False_Ensembles_eq _ Empty_set).
 constructor.
-Qed.
-
-Lemma injection_preserves_cardinal: forall (X Y:Type)
-  (f:X->Y) (n:nat) (S:Ensemble X), cardinal _ S n ->
-  injective f -> cardinal _ (Im S f) n.
-Proof.
-intros.
-induction H.
-- rewrite image_empty.
-  constructor.
-- rewrite Im_add.
-  constructor; trivial.
-  red; intro H3; inversion H3.
-  subst. apply H0 in H4. subst.
-  contradiction.
 Qed.
 
 Lemma FiniteT_nat_cardinal_option:

--- a/theories/ZornsLemma/Finite_sets.v
+++ b/theories/ZornsLemma/Finite_sets.v
@@ -1,6 +1,7 @@
 From Coq Require Import Classical.
 From Coq Require Export Finite_sets Finite_sets_facts.
-From ZornsLemma Require Import EnsemblesImplicit FiniteImplicit Powerset_facts.
+From ZornsLemma Require Import EnsemblesImplicit Families
+  FiniteImplicit Powerset_facts.
 
 Lemma finite_couple {X} (x y : X) :
   Finite (Couple x y).
@@ -56,4 +57,21 @@ Proof.
         exists x0; split; auto with sets.
       * inversion H5; subst; clear H5.
         exists x; auto with sets.
+Qed.
+
+(* note that the converse direction is not true.
+   Consider for example the intersection of the
+   open intervals [ (0, 1/n) ], which is empty and thus finite.
+   If you like, a non-empty intersection is achieved by
+   intersecting the intervals [ [0, 1/n) ].
+ *)
+Lemma FamilyIntersection_Finite (X : Type) (F : Family X) :
+  (exists U, In F U /\ Finite U) ->
+  Finite (FamilyIntersection F).
+Proof.
+  intros.
+  destruct H as [U [? ?]].
+  apply Finite_downward_closed with U; auto.
+  red; intros.
+  destruct H1. apply H1. assumption.
 Qed.

--- a/theories/ZornsLemma/Image.v
+++ b/theories/ZornsLemma/Image.v
@@ -82,6 +82,20 @@ Proof.
     all: assumption.
 Qed.
 
+(* The inclusion [Intersection_Im] holds always.
+   The other inclusion is eqiuvalent to injectivity. *)
+Lemma Intersection_Im {X Y : Type} (f : X -> Y) (U V : Ensemble X) :
+  Included
+    (Im (Intersection U V) f)
+    (Intersection (Im U f) (Im V f)).
+Proof.
+  intros y Hy.
+  destruct Hy as [x Hx y Hy].
+  subst.
+  destruct Hx as [x HU HV].
+  split; exists x; auto.
+Qed.
+
 Lemma Im_id {X : Type} (U : Ensemble X) :
   Im U id = U.
 Proof.

--- a/theories/ZornsLemma/Powerset_facts.v
+++ b/theories/ZornsLemma/Powerset_facts.v
@@ -163,10 +163,22 @@ Proof.
   apply H. constructor.
 Qed.
 
-Lemma Singleton_injective {T : Type} : forall x y : T, Singleton x = Singleton y -> x = y.
+Lemma Singleton_injective {T : Type} :
+  forall x y : T, Singleton x = Singleton y -> x = y.
 Proof.
 intros.
 assert (In (Singleton x) x) by constructor.
 rewrite H in H0.
 now destruct H0.
+Qed.
+
+Definition Union_add_r := Union_add.
+
+Corollary Union_add_l {X : Type} (A B : Ensemble X) (x : X) :
+  Add (Union A B) x = Union (Add A x) B.
+Proof.
+  rewrite (Union_commutative _ (Add _ _)).
+  rewrite <- (Union_add_r _ _ A).
+  rewrite (Union_commutative _ B).
+  reflexivity.
 Qed.


### PR DESCRIPTION
By implementing topological properties as typeclasses we can let Coq automatically infer properties. This way for concrete topological spaces we only have to prove their strongest properties (normality, metrizability) and Coq will infer the rest when we need them. Currently only separation axioms and metrizability are implemented as classes in this branch.

I haven't considered all possible consequences of this design decision. Such inference is very useful, though typeclasses are just one way of doing it. Are there other feasible approaches? Will the resulting typeclass hierarchy break the inference algorithm, if too many topological properties and relations are added?
Applying the hierarchy is a bit wonky. Consider [TietzeExtension.v#L651-L652](https://github.com/coq-community/topology/blob/3d0a0a149bccad91cbc2ae1d03398342f21bfc57/theories/Topology/TietzeExtension.v#L651-L652). In the proof we want to use that `RTop` is T₁. Ideally we would only write `apply T1_sep` and be done with it. Now I had to explicitly name `RTop` and invoke the inference algorithm with `typeclasses eauto`.

Something I couldn't do with my approach: Let "hereditary" be a predicate for topological properties. Then how can I make Coq automatically apply hereditary-ness? Currently such instances have to be written manually and are separate from any Coq-internal predicate "hereditary".