### PR TITLE
Minor changes, some breaking

### DIFF
--- a/theories/Topology/Completeness.v
+++ b/theories/Topology/Completeness.v
@@ -18,7 +18,7 @@ Lemma convergent_sequence_is_cauchy:
   net_limit x x0 -> cauchy x.
 Proof.
 intros.
-destruct (MetricTopology_metrizable X d d_metric x0).
+destruct (MetricTopology_metrized X d d_metric x0).
 red; intros.
 destruct (H (open_ball d x0 (eps/2))) as [N].
 - Opaque In. apply open_neighborhood_basis_elements. Transparent In.
@@ -45,14 +45,14 @@ Lemma cauchy_sequence_with_cluster_point_converges:
 Proof.
 intros.
 apply metric_space_net_limit with d.
-- apply MetricTopology_metrizable.
+- apply MetricTopology_metrized.
 - intros.
   red; intros.
   destruct (H (eps/2)) as [N].
   + lra.
   + pose (U := open_ball d x0 (eps/2)).
     assert (open_neighborhood U x0 (X:=MetricTopology d d_metric)).
-  { apply MetricTopology_metrizable.
+  { apply MetricTopology_metrized.
     constructor.
     lra. }
     destruct H3.
@@ -116,12 +116,12 @@ destruct (H y) as [y0].
     destruct (x i); trivial. }
   exists (exist _ y0 H3).
   apply metric_space_net_limit with d_restriction.
-  + apply MetricTopology_metrizable.
+  + apply MetricTopology_metrized.
   + intros.
     unfold d_restriction; simpl.
     apply metric_space_net_limit_converse with
       (MetricTopology d d_metric); trivial.
-    apply MetricTopology_metrizable.
+    apply MetricTopology_metrized.
 Qed.
 
 Lemma complete_subset_is_closed:
@@ -140,7 +140,7 @@ cut (Included (closure F (X:=MetricTopology d d_metric)) F).
     (forall n:nat, In F (y n)) /\ net_limit y x).
 { apply first_countable_sequence_closure; trivial.
   apply metrizable_impl_first_countable.
-  exists d; trivial; apply MetricTopology_metrizable. }
+  exists d; trivial; apply MetricTopology_metrized. }
   destruct H1 as [y []].
   pose (y' := ((fun n:nat => exist _ (y n) (H1 n)) :
                Net nat_DS (MetricTopology d_restriction d_restriction_metric))).
@@ -163,14 +163,14 @@ cut (Included (closure F (X:=MetricTopology d d_metric)) F).
     apply normal_sep_impl_T3_sep.
     apply metrizable_impl_normal_sep.
     exists d; trivial.
-    apply MetricTopology_metrizable. }
+    apply MetricTopology_metrized. }
     now apply H7. }
     now rewrite H7.
   + apply metric_space_net_limit with d.
-    * apply MetricTopology_metrizable.
+    * apply MetricTopology_metrized.
     * exact (metric_space_net_limit_converse
         (MetricTopology d_restriction d_restriction_metric)
-        d_restriction (MetricTopology_metrizable _ d_restriction
+        d_restriction (MetricTopology_metrized _ d_restriction
                              d_restriction_metric)
         nat_DS y' (exist _ x0 i) H5).
 Qed.

--- a/theories/Topology/Completion.v
+++ b/theories/Topology/Completion.v
@@ -76,14 +76,14 @@ cut (exists Y:Type, exists i:X->Y, exists d':Y->Y->R,
             ** constructor.
             ** now apply subset_eq_compat.
       -- pose proof (metric_space_net_limit_converse (MetricTopology d' d'_metric) d'
-           (MetricTopology_metrizable _ d' d'_metric) nat_DS x0 x H4).
-         apply metric_space_net_limit with (1:=MetricTopology_metrizable _ _ d'_metric0).
+           (MetricTopology_metrized _ d' d'_metric) nat_DS x0 x H4).
+         apply metric_space_net_limit with (1:=MetricTopology_metrized _ _ d'_metric0).
          (*
          destruct (metric_space_net_limit (MetricTopology d' d'_metric)
-           d' (MetricTopology_metrizable _ d' d'_metric) nat_DS x0 x).
+           d' (MetricTopology_metrized _ d' d'_metric) nat_DS x0 x).
          pose proof (H6 H4); clear H6 H7.
          apply <- (metric_space_net_limit (MetricTopology _ d'_metric0)
-           _ (MetricTopology_metrizable _ _ d'_metric0) nat_DS). *)
+           _ (MetricTopology_metrized _ _ d'_metric0) nat_DS). *)
          intros.
          destruct (H6 eps H7).
          exists x1.
@@ -95,7 +95,7 @@ cut (exists Y:Type, exists i:X->Y, exists d':Y->Y->R,
          now apply H8.
     * apply metrizable_impl_first_countable.
       exists d'; trivial.
-      apply MetricTopology_metrizable.
+      apply MetricTopology_metrized.
   + intros.
     now simpl.
   + apply (closed_subset_of_complete_is_complete Y d' d'_metric F);

--- a/theories/Topology/MetricSpaces.v
+++ b/theories/Topology/MetricSpaces.v
@@ -102,7 +102,7 @@ Inductive metrizable (X:TopologicalSpace) : Prop :=
     metric d -> metrizes X d ->
     metrizable X.
 
-Lemma MetricTopology_metrizable: forall (X:Type) (d:X->X->R)
+Lemma MetricTopology_metrized: forall (X:Type) (d:X->X->R)
   (d_metric: metric d),
   metrizes (MetricTopology d d_metric) d.
 Proof.
@@ -110,6 +110,14 @@ intros.
 red.
 intros.
 apply Build_TopologicalSpace_from_open_neighborhood_bases_basis.
+Qed.
+
+Corollary MetricTopology_metrizable X (d:X->X->R) d_metric :
+  metrizable (MetricTopology d d_metric).
+Proof.
+apply intro_metrizable with (d := d).
+- assumption.
+- apply MetricTopology_metrized.
 Qed.
 
 Lemma metric_open_ball_In X (d : X -> X -> R) :

--- a/theories/Topology/ProductTopology.v
+++ b/theories/Topology/ProductTopology.v
@@ -358,11 +358,11 @@ Variable f:point_set X -> point_set Y -> point_set Z.
 
 Definition continuous_2arg :=
   continuous (fun p:point_set X * point_set Y =>
-              let (x,y):=p in f x y)
+                f (fst p) (snd p))
   (X:=ProductTopology2 X Y).
 Definition continuous_at_2arg (x:point_set X) (y:point_set Y) :=
   continuous_at (fun p:point_set X * point_set Y =>
-                 let (x,y):=p in f x y)  (x, y)
+                 f (fst p) (snd p))  (x, y)
   (X:=ProductTopology2 X Y).
 
 Lemma continuous_2arg_func_continuous_everywhere:
@@ -398,9 +398,10 @@ Lemma continuous_composition_at_2arg:
   continuous_at (fun w:point_set W => f (g w) (h w)) w.
 Proof.
 intros.
+red in H.
 apply (continuous_composition_at
   (fun p:point_set (ProductTopology2 X Y) =>
-      let (x,y):=p in f x y)
+      f (fst p) (snd p))
   (fun w:point_set W => (g w, h w))); trivial.
 now apply product2_map_continuous_at.
 Qed.

--- a/theories/Topology/RFuncContinuity.v
+++ b/theories/Topology/RFuncContinuity.v
@@ -81,6 +81,7 @@ apply continuous_at_neighborhood_basis with
   + destruct x0 as [x' y'],
              H1 as [[[] []]].
     unfold R_metric.
+    simpl.
     replace (x'+y' - (x+y)) with ((x'-x) + (y'-y)) by ring.
     apply Rle_lt_trans with (Rabs (x'-x) + Rabs(y'-y)).
     * apply Rabs_triang.
@@ -167,9 +168,8 @@ pose proof (RTop_metrization 0).
 apply continuous_at_neighborhood_basis with
   (metric_topology_neighborhood_basis R_metric 0).
 - apply open_neighborhood_basis_is_neighborhood_basis.
-  replace (0*0) with 0 by auto with real.
-  apply H.
-
+  simpl. rewrite Rmult_0_r.
+  assumption.
 - intros.
   destruct H0.
   exists (characteristic_function_to_ensemble
@@ -192,9 +192,8 @@ apply continuous_at_neighborhood_basis with
     destruct x as [x y].
     destruct H1 as [[] []].
     unfold R_metric in *.
-    replace (x*y-0) with (x*y) by auto with real.
-    replace (x-0) with x in H1 by auto with real.
-    replace (y-0) with y in H2 by auto with real.
+    simpl.
+    rewrite Rminus_0_r in *.
     rewrite Rabs_mult.
     replace r with (r*1) by auto with real.
     apply Rmult_le_0_lt_compat;

--- a/theories/Topology/RTopology.v
+++ b/theories/Topology/RTopology.v
@@ -594,7 +594,7 @@ destruct (bounded_real_net_has_cluster_point nat_DS x a b) as [x0].
 - exists x0.
   apply cauchy_sequence_with_cluster_point_converges; trivial.
   apply metric_space_net_cluster_point with R_metric;
-    try apply MetricTopology_metrizable.
+    try apply MetricTopology_metrized.
   intros.
   apply metric_space_net_cluster_point_converse with RTop; trivial.
   apply RTop_metrization.

--- a/theories/Topology/TietzeExtension.v
+++ b/theories/Topology/TietzeExtension.v
@@ -416,7 +416,7 @@ split.
             R_metric_is_metric X_nonempty).
   + apply (uniform_metric_is_metric _ _ R_metric (fun _:X => 0)
               R_metric_is_metric X_nonempty).
-  + apply MetricTopology_metrizable.
+  + apply MetricTopology_metrized.
 Defined.
 
 Lemma Tietze_extension_func_bound: forall x:X,
@@ -453,7 +453,7 @@ apply Rle_trans with (uniform_metric _ _ R_metric_is_metric X_nonempty
 - apply lt_plus_epsilon_le.
   intros.
   unshelve refine (let H1:=metric_space_net_limit_converse _ _ _ _ _ _ n eps H0 in _); [ | | clearbody H1 ]; shelve_unifiable.
-  { apply MetricTopology_metrizable. }
+  { apply MetricTopology_metrized. }
   destruct H1 as [N].
   refine (Rle_lt_trans _ _ _
     (triangle_inequality _ _ _ _ (convert_approx_to_uniform_space N) _) _).
@@ -495,7 +495,7 @@ unfold Tietze_extension_func;
 assert (eps/2 > 0) by lra.
 unshelve refine (let H1:=metric_space_net_limit_converse _ _ _ _ _ _ n (eps/2) H0
           in _); [ | | clearbody H1 ]; shelve_unifiable.
-{ apply MetricTopology_metrizable. }
+{ apply MetricTopology_metrized. }
 destruct H1 as [N1].
 assert (Rabs (2/3) < 1).
 { rewrite Rabs_right; lra. }
@@ -537,7 +537,7 @@ assert (continuous (fun x:R => x)
   apply metric_space_fun_continuity with R_metric R_metric;
     intros.
   - apply RTop_metrization.
-  - apply MetricTopology_metrizable.
+  - apply MetricTopology_metrized.
   - now exists eps. }
 assert (continuous (fun x:R => x)
   (X:=MetricTopology R_metric R_metric_is_metric) (Y:=RTop)).
@@ -545,7 +545,7 @@ assert (continuous (fun x:R => x)
   intros.
   apply metric_space_fun_continuity with R_metric R_metric;
     intros.
-  - apply MetricTopology_metrizable.
+  - apply MetricTopology_metrized.
   - apply RTop_metrization.
   - now exists eps. }
 intros.

--- a/theories/Topology/TietzeExtension.v
+++ b/theories/Topology/TietzeExtension.v
@@ -666,42 +666,44 @@ destruct (UrysohnsLemma _ H G F) as [phi [? [? []]]]; trivial.
   lra.
 - exists (fun x => phi x * g0 x).
   split.
-  + apply pointwise_continuity.
+  { apply pointwise_continuity.
     intros.
     apply product_continuous;
       now apply continuous_func_continuous_everywhere.
-  + split.
-    * intros.
-      rewrite H9.
-      ** replace (1*g0 (subspace_inc F x)) with (g0 (subspace_inc F x)) by
-           auto with real.
-         apply H4.
-      ** now destruct x.
-    * intros.
-      apply and_comm, Rabs_def2.
-      rewrite Rabs_mult.
-      rewrite (Rabs_right (phi x));
-        [ | apply Rle_ge; apply H7 ].
-      destruct (classic (In G x)).
-      { rewrite H8; trivial. lra. }
-      assert (Rabs (g0 x) < 1).
-      { assert (Rabs (g0 x) <= 1).
-        { destruct (H5 x).
-          unfold Rabs; destruct Rcase_abs; lra. }
-        destruct H11; trivial.
-        contradiction H10.
-        unfold Rabs in H11.
-        destruct Rcase_abs in H11;
-          constructor.
-        - lra.
-        - now left. }
-      destruct (H7 x).
-      apply Rle_lt_trans with (Rabs (g0 x)); trivial.
-      pattern (Rabs (g0 x)) at 2.
-      replace (Rabs (g0 x)) with (1*Rabs (g0 x)) by
+  }
+  split.
+  { intros.
+    rewrite H9.
+    - replace (1*g0 (subspace_inc F x)) with (g0 (subspace_inc F x)) by
         auto with real.
-      apply Rmult_le_compat_r; trivial.
-      apply Rabs_pos.
+      apply H4.
+    - now destruct x.
+  }
+  intros.
+  apply and_comm, Rabs_def2.
+  rewrite Rabs_mult.
+  rewrite (Rabs_right (phi x));
+    [ | apply Rle_ge; apply H7 ].
+  destruct (classic (In G x)).
+  { rewrite H8; trivial. lra. }
+  assert (Rabs (g0 x) < 1).
+  { assert (Rabs (g0 x) <= 1).
+    { destruct (H5 x).
+      unfold Rabs; destruct Rcase_abs; lra. }
+    destruct H11; trivial.
+    contradiction H10.
+    unfold Rabs in H11.
+    destruct Rcase_abs in H11;
+      constructor.
+    - lra.
+    - now left. }
+  destruct (H7 x).
+  apply Rle_lt_trans with (Rabs (g0 x)); trivial.
+  pattern (Rabs (g0 x)) at 2.
+  replace (Rabs (g0 x)) with (1*Rabs (g0 x)) by
+    auto with real.
+  apply Rmult_le_compat_r; trivial.
+  apply Rabs_pos.
 Qed.
 
 Theorem Tietze_extension_theorem: forall (X:TopologicalSpace)

--- a/theories/Topology/UniformTopology.v
+++ b/theories/Topology/UniformTopology.v
@@ -125,7 +125,7 @@ assert (forall y:Net nat_DS (MetricTopology d d_metric), cauchy d y ->
     apply T3_sep_impl_Hausdorff.
     apply normal_sep_impl_T3_sep.
     apply metrizable_impl_normal_sep.
-    exists d; trivial; apply MetricTopology_metrizable.
+    exists d; trivial; apply MetricTopology_metrized.
 }
 red; intros f ?.
 unshelve refine (let H1 := _ in let H2 := _ in ex_intro _
@@ -166,7 +166,7 @@ unshelve refine (let H1 := _ in let H2 := _ in ex_intro _
     intros.
     destruct cauchy_limit; simpl.
     pose proof (metric_space_net_limit_converse _ _
-      (MetricTopology_metrizable _ d d_metric) nat_DS
+      (MetricTopology_metrized _ d d_metric) nat_DS
       (fun n:nat => proj1_sig (f n) x) x0 n).
     destruct (H7 eps H6) as [i0].
     pose (N' := max N i0).
@@ -201,7 +201,7 @@ unshelve refine (let H1 := _ in let H2 := _ in ex_intro _
   }
   auto with real.
 - apply metric_space_net_limit with uniform_metric.
-  { apply MetricTopology_metrizable. }
+  { apply MetricTopology_metrized. }
   intros.
   assert (eps/2 > 0) by lra.
   destruct (H0 (eps/2) H4) as [N].
@@ -217,7 +217,7 @@ unshelve refine (let H1 := _ in let H2 := _ in ex_intro _
   destruct (cauchy_limit (fun n:nat => proj1_sig (f n) x0) (H1 x0));
     simpl.
   pose proof (metric_space_net_limit_converse _ _
-    (MetricTopology_metrizable _ d d_metric) nat_DS
+    (MetricTopology_metrized _ d d_metric) nat_DS
     (fun n:nat => proj1_sig (f n) x0) x1 n).
   destruct (H9 eps0 H8) as [N'].
   pose (N'' := max N N').
@@ -276,7 +276,7 @@ red; intros f0 ?.
 red.
 apply first_countable_sequence_closure in H.
 - destruct H as [f []].
-  pose proof (MetricTopology_metrizable _ d d_metric
+  pose proof (MetricTopology_metrized _ d d_metric
     (proj1_sig f0 x0)).
   apply open_neighborhood_basis_is_neighborhood_basis in H1.
   apply continuous_at_neighborhood_basis with (1:=H1).
@@ -284,14 +284,14 @@ apply first_countable_sequence_closure in H.
   destruct H2.
   assert (r/3>0) by lra.
   destruct (metric_space_net_limit_converse _ _
-    (MetricTopology_metrizable _ _
+    (MetricTopology_metrized _ _
        (uniform_metric_is_metric _ _ d y0 d_metric X_inh))
     nat_DS f f0 H0 (r/3) H3) as [N].
   assert (neighborhood
     (inverse_image (proj1_sig (f N))
        (open_ball d (proj1_sig (f N) x0) (r/3))) x0).
   { apply H.
-    pose proof (MetricTopology_metrizable _ d d_metric
+    pose proof (MetricTopology_metrized _ d d_metric
       (proj1_sig (f N) x0)).
     apply open_neighborhood_basis_is_neighborhood_basis in H5.
     apply H5.
@@ -336,7 +336,7 @@ apply first_countable_sequence_closure in H.
 - apply metrizable_impl_first_countable.
   exists (uniform_metric d y0 d_metric X_inh).
   + exact (uniform_metric_is_metric _ _ d y0 d_metric X_inh).
-  + apply MetricTopology_metrizable.
+  + apply MetricTopology_metrized.
 Qed.
 
 Lemma continuous_functions_closed_in_uniform_metric:

--- a/theories/Topology/UrysohnsLemma.v
+++ b/theories/Topology/UrysohnsLemma.v
@@ -717,72 +717,67 @@ Theorem UrysohnsLemma: forall X:TopologicalSpace, normal_sep X ->
   (forall x:X, In F x -> f x = 0) /\
   (forall x:X, In G x -> f x = 1).
 Proof.
-intros.
-destruct H.
-destruct (H3 F G H0 H1 H2) as [U [V [? [? [? [? ?]]]]]].
-assert (Included (closure U) (Complement G)).
-{ assert (Included (closure U) (Complement V)).
-  { apply closure_minimal.
-    - red. now rewrite Complement_Complement.
-    - red. intros.
-      intro.
-      eapply Noone_in_empty.
-      rewrite <- H8.
-      econstructor;
-        eassumption. }
-  assert (Included (Complement V) (Complement G)).
-  { red. intros.
-    intro.
-    contradiction H10.
-    now apply H7. }
-  auto with sets. }
+intros X [_ HX_normal] F G HF HG HFG.
+destruct (HX_normal F G HF HG HFG) as [U [V [HU [HV [HFU [HGV HUV]]]]]].
 assert (inhabited (forall F U:Ensemble X, closed F ->
   open U -> Included F U ->
   { V:Ensemble X | open V /\ Included F V /\
-                               Included (closure V) U })).
+                               Included (closure V) U }))
+       as [normal_sep_fun].
 { destruct (choice (fun (FU_pair:
     {p:Ensemble X * Ensemble X |
      closed (fst p) /\ open (snd p) /\ Included (fst p) (snd p)})
     (V0:Ensemble X) =>
      open V0 /\ Included (fst (proj1_sig FU_pair)) V0 /\
      Included (closure V0) (snd (proj1_sig FU_pair)))) as
-    [pre_choice_fun].
-  - intro p.
-    destruct p as [[F0 U0]].
-    simpl in a.
-    simpl.
-    destruct a as [? []].
-    destruct (H3 F0 (Complement U0)) as [U1 [V1 []]]; trivial.
-    + red. now rewrite Complement_Complement.
-    + extensionality_ensembles_inv.
-      contradiction H15.
-      now apply H12.
-    + destruct H14 as [? [? []]].
-      exists U1.
-      repeat split; trivial.
-      assert (Included (closure U1) (Complement V1)).
-      { apply closure_minimal.
-        - red. now rewrite Complement_Complement.
-        - red. intros.
-          intro.
-          eapply Noone_in_empty.
-          rewrite <- H17.
-          constructor;
-            eassumption. }
-      assert (Included (Complement V1) U0).
-      { red. intros.
-        apply NNPP. intro.
-        contradiction H19.
-        now apply H16. }
-      auto with sets.
-  - exists.
-    intros.
+    [pre_choice_fun Hpre_choice_fun].
+  2: {
+    exists.
+    intros F0 U0 HF0 HU0 HF0U0.
     exists (pre_choice_fun (exist _ (F0,U0)
-      (conj H11 (conj H12 H13)))).
-    apply H10. }
-destruct H10 as [normal_sep_fun].
-exists (Urysohns_Lemma_function _ normal_sep_fun
-  U (Complement G) H4 H1 H9).
+      (conj HF0 (conj HU0 HF0U0)))).
+    apply Hpre_choice_fun. }
+  intros [[F0 U0] [HF0 [HU0 HF0U0]]].
+  simpl in *.
+  destruct (HX_normal F0 (Complement U0))
+    as [U1 [V1 [? [? [? [H_CU0_V1 HU1V1]]]]]]; trivial.
+  { red. now rewrite Complement_Complement. }
+  { extensionality_ensembles_inv.
+    subst.
+    match goal with
+    | H : In F0 _ |- _ =>
+      apply HF0U0 in H
+    end.
+    contradiction. }
+  exists U1.
+  repeat split; trivial.
+  transitivity (Complement V1).
+  - apply closure_minimal.
+    + red. now rewrite Complement_Complement.
+    + red. intros.
+      intro.
+      eapply Noone_in_empty.
+      rewrite <- HU1V1.
+      constructor;
+        eassumption.
+  - red. intros.
+    apply NNPP. intros Hx.
+    apply H_CU0_V1 in Hx.
+    contradiction. }
+unshelve eexists (Urysohns_Lemma_function _ normal_sep_fun
+  U (Complement G) HU HG _).
+{ transitivity (Complement V).
+  - apply closure_minimal.
+    + red. now rewrite Complement_Complement.
+    + red. intros.
+      intro.
+      eapply Noone_in_empty.
+      rewrite <- HUV.
+      econstructor;
+        eassumption.
+  - red. intros x Hx ?.
+    contradiction Hx.
+    now apply HGV. }
 split.
 { apply Urysohns_Lemma_function_continuous. }
 split.

--- a/theories/ZornsLemma/Powerset_facts.v
+++ b/theories/ZornsLemma/Powerset_facts.v
@@ -5,7 +5,19 @@
 
 From Coq.Sets Require Export Powerset_facts.
 From ZornsLemma Require Export EnsemblesImplicit EnsemblesTactics.
-From Coq Require Import Classical_Prop.
+From Coq Require Import Classical_Prop RelationClasses.
+
+Global Instance Included_PreOrder {X : Type} :
+  PreOrder (@Included X).
+Proof.
+firstorder.
+Qed.
+
+Global Instance Same_set_Equivalence {X : Type} :
+  Equivalence (@Same_set X).
+Proof.
+firstorder.
+Qed.
 
 Lemma Intersection_Full_set
   {X : Type}


### PR DESCRIPTION
@stop-cran what do you think?

Breaking changes:
* Change the definition of `continuous_2arg`
* Rename `MetricTopology_metrizable` to `MetricTopolgoy_metrized`

Additions:
* Use `RelationClasses` for the first time in this library, on `Included` and `Same_set`.

Changes not affecting behaviour:
* Restructure the proof of `UrysohnLemma` (uses the above addition)
* Restructure a proof in TietzeExtension.v