### PR TITLE
Rework `Completeness` and `Completion`

### DIFF
--- a/theories/Topology/Completeness.v
+++ b/theories/Topology/Completeness.v
@@ -136,6 +136,20 @@ apply Rle_lt_trans with (d x0 (x m) + d (x m) (x n)).
   + now apply HN.
 Qed.
 
+Corollary complete_cauchy_cluster_points :
+  (forall x:nat -> X, cauchy d x ->
+      exists x0:X, net_cluster_point x x0 (I:=nat_DS)) ->
+  complete d.
+Proof.
+  intros H.
+  apply complete_net_limit_char.
+  intros x Hx.
+  specialize (H x Hx) as [x0 Hx0].
+  exists x0.
+  apply cauchy_sequence_with_cluster_point_converges;
+    auto.
+Qed.
+
 End Completeness.
 
 Section closed_subset_of_complete.

--- a/theories/Topology/Completeness.v
+++ b/theories/Topology/Completeness.v
@@ -1,4 +1,5 @@
-Require Export MetricSpaces.
+From Topology Require Export MetricSpaces.
+From Topology Require Import SubspaceTopology.
 Require Import Psatz.
 From Coq Require Import ProofIrrelevance.
 
@@ -132,12 +133,8 @@ Variable F:Ensemble X.
 
 Let FT := { x:X | In F x }.
 Let d_restriction := fun x y:FT => d (proj1_sig x) (proj1_sig y).
-
-Lemma d_restriction_metric: metric d_restriction.
-Proof.
-constructor; intros; try destruct x; try destruct y; try destruct z;
-  try apply subset_eq_compat; apply d_metric; trivial.
-Qed.
+Let d_restriction_metric :=
+      MetricSpaces.d_restriction_metric d d_metric F.
 
 Lemma closed_subset_of_complete_is_complete:
   complete d d_metric ->

--- a/theories/Topology/Completion.v
+++ b/theories/Topology/Completion.v
@@ -33,7 +33,7 @@ Section Completion.
   Lemma completion_exists_nondense :
     exists (Y : Type) (d' : Y -> Y -> R) (d'_metric : metric d')
       (i : X -> Y),
-      isometry d d' i /\ complete d' d'_metric.
+      isometry d d' i /\ complete d'.
   Proof.
     destruct (classic (inhabited X)).
     2: {
@@ -82,7 +82,7 @@ Section Completion.
       (d' : Y -> Y -> R) (d'_metric : metric d'),
       metrizes Y d' /\
         dense (Im Full_set i) /\
-        isometry d d' i /\ complete d' d'_metric.
+        isometry d d' i /\ complete d'.
   Proof.
     intros.
     (* first of all, it suffices to construct a (Y, d') without the
@@ -117,7 +117,10 @@ Section Completion.
     2: {
       apply
         (@closed_subset_of_complete_is_complete
-           Y d' d'_metric F d'_comp (closure_closed _)).
+           (MetricTopology d' d'_metric) d' d'_metric
+           (MetricTopology_metrized _ d' d'_metric)
+           F d'_comp (closure_closed _)
+        ).
     }
     pose proof (@dense_in_closure
                   (MetricTopology d' d'_metric) (Im Full_set i)).

--- a/theories/Topology/RTopology.v
+++ b/theories/Topology/RTopology.v
@@ -570,8 +570,9 @@ Qed.
 
 Lemma R_metric_complete: complete R_metric.
 Proof.
-rewrite @complete_net_limit_char with (X := RTop).
-2: apply RTop_metrization.
+apply complete_cauchy_cluster_points with (X := RTop).
+1: apply R_metric_is_metric.
+1: apply RTop_metrization.
 intros x Hx.
 pose proof (cauchy_impl_bounded _ R_metric_is_metric x Hx)
   as [p [r Hpr]].
@@ -583,11 +584,7 @@ destruct (bounded_real_net_has_cluster_point
   unfold R_metric, Rabs in Hn.
   destruct (Rcase_abs _); lra.
 }
-exists x0.
-eapply cauchy_sequence_with_cluster_point_converges;
-  eauto.
-- apply R_metric_is_metric.
-- apply RTop_metrization.
+exists x0. assumption.
 Qed.
 
 Lemma RTop_subbasis_rational_beams :

--- a/theories/Topology/RTopology.v
+++ b/theories/Topology/RTopology.v
@@ -539,7 +539,7 @@ Lemma R_cauchy_sequence_bounded: forall x:nat->R,
 Proof.
 intros x Hx.
 pose proof (cauchy_impl_bounded
-              R R_metric R_metric_is_metric x Hx)
+              R_metric R_metric_is_metric x Hx)
   as [p [r]].
 clear Hx.
 exists (p + r).
@@ -556,7 +556,7 @@ Lemma R_cauchy_sequence_lower_bound: forall x:nat->R,
 Proof.
 intros x Hx.
 pose proof (cauchy_impl_bounded
-              R R_metric R_metric_is_metric x Hx)
+              R_metric R_metric_is_metric x Hx)
   as [p [r]].
 clear Hx.
 exists (p - r).
@@ -568,26 +568,26 @@ unfold R_metric, Rabs in H.
 destruct (Rcase_abs _); lra.
 Qed.
 
-Lemma R_metric_complete: complete R_metric R_metric_is_metric.
+Lemma R_metric_complete: complete R_metric.
 Proof.
-red. intros.
-pose proof (cauchy_impl_bounded _ _ R_metric_is_metric x H)
+rewrite @complete_net_limit_char with (X := RTop).
+2: apply RTop_metrization.
+intros x Hx.
+pose proof (cauchy_impl_bounded _ R_metric_is_metric x Hx)
   as [p [r Hpr]].
 destruct (bounded_real_net_has_cluster_point
             nat_DS x (p - r) (p + r)) as [x0].
 { intros n.
-  unshelve epose proof (Hpr (x n) _) as [].
+  unshelve epose proof (Hpr (x n) _) as [Hn].
   { apply Im_def. constructor. }
-  unfold R_metric, Rabs in H0.
+  unfold R_metric, Rabs in Hn.
   destruct (Rcase_abs _); lra.
 }
 exists x0.
-apply cauchy_sequence_with_cluster_point_converges; trivial.
-apply metric_space_net_cluster_point with R_metric;
-  try apply MetricTopology_metrized.
-intros.
-apply metric_space_net_cluster_point_converse with RTop; trivial.
-apply RTop_metrization.
+eapply cauchy_sequence_with_cluster_point_converges;
+  eauto.
+- apply R_metric_is_metric.
+- apply RTop_metrization.
 Qed.
 
 Lemma RTop_subbasis_rational_beams :

--- a/theories/Topology/TietzeExtension.v
+++ b/theories/Topology/TietzeExtension.v
@@ -401,17 +401,13 @@ refine (proj1_sig (proj1_sig (constructive_definite_description
                     R_metric_is_metric X_nonempty)) _))).
 apply -> unique_existence.
 split.
-- assert (complete (uniform_metric R_metric (fun _:X => 0)
-                      R_metric_is_metric X_nonempty)
-            (uniform_metric_is_metric _ _ _ _ _ _)).
-  { apply uniform_metric_complete.
-    exact R_metric_complete. }
-  apply H.
-  exact extension_approximation_seq_cauchy.
+- unshelve eapply
+    (proj1 (@complete_net_limit_char _ _ _)).
+  4: exact extension_approximation_seq_cauchy.
+  + apply MetricTopology_metrized.
+  + apply uniform_metric_complete, R_metric_complete.
 - apply Hausdorff_impl_net_limit_unique.
-  apply T3_sep_impl_Hausdorff.
-  apply normal_sep_impl_T3_sep.
-  apply metrizable_impl_normal_sep.
+  apply metrizable_Hausdorff.
   exists (uniform_metric R_metric (fun _:X => 0)
             R_metric_is_metric X_nonempty).
   + apply (uniform_metric_is_metric _ _ R_metric (fun _:X => 0)

--- a/theories/Topology/UniformTopology.v
+++ b/theories/Topology/UniformTopology.v
@@ -143,10 +143,14 @@ Definition UniformTopology_metrizable :
   metrizable UniformTopology :=
   MetricTopology_metrizable _ _ _.
 
-Lemma uniform_metric_complete: complete d d_metric ->
-  complete uniform_metric uniform_metric_is_metric.
+Lemma uniform_metric_complete: complete d ->
+  complete uniform_metric.
 Proof.
 intros.
+rewrite @complete_net_limit_char with (X := MetricTopology d d_metric) in H.
+2: apply MetricTopology_metrized.
+rewrite @complete_net_limit_char with (X := UniformTopology).
+2: apply MetricTopology_metrized.
 assert (forall y:Net nat_DS (MetricTopology d d_metric), cauchy d y ->
   { y0:Y | net_limit y y0 }) as cauchy_limit.
 { intros.
@@ -159,7 +163,7 @@ assert (forall y:Net nat_DS (MetricTopology d d_metric), cauchy d y ->
     apply metrizable_impl_normal_sep.
     exists d; trivial; apply MetricTopology_metrized.
 }
-red; intros f ?.
+intros f ?.
 unshelve refine (let H1 := _ in let H2 := _ in ex_intro _
   (exist _ (fun x:X => proj1_sig (cauchy_limit
                   (fun n:nat => proj1_sig (f n) x) (H1 x))) H2) _); [ | clearbody H1 | clearbody H1 H2 ].


### PR DESCRIPTION
Before this PR, the definition of `complete` and many statements in `Completeness` and `Completion` explicitly mention the `MetricTopology`. This makes it hard to use these results with arbitrary metrizable topologies which might not be defined via their metric. For example `RTop`.

This PR uses the assumption `metrizes X d` instead, whenever possible.

The statement of `completion_exists` has been adapted as well, and the proof has been split into separate lemmas. The lemma `d_restriction_metric` has been moved to `MetricSpaces`.